### PR TITLE
Added a front-end status indicator for endorsed posts

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -90,6 +90,10 @@ define('forum/topic/postTools', [
 
         handleSelectionTooltip();
 
+        postContainer.on('click', '[component="post/endorse"]', function () {
+            onEndorseClicked($(this), tid);
+        });
+
         postContainer.on('click', '[component="post/quote"]', function () {
             onQuoteClicked($(this), tid);
         });
@@ -254,7 +258,34 @@ define('forum/topic/postTools', [
             openChat($(this));
         });
     }
+    async function onEndorseClicked(button, tid) {
+        const selectedNode = await getSelectedNode();
+        showStaleWarning(async function () {
+            const username = await getUserSlug(button);
+            const toPid = getData(button, 'data-pid');
 
+            function endorse(text) {
+                hooks.fire('action:endorsement.addEndorsement', {
+                    tid: tid,
+                    pid: toPid,
+                    username: username,
+                    topicName: ajaxify.data.titleRaw,
+                    text: text,
+                  });
+                }
+      
+                if (selectedNode.text && toPid && toPid === selectedNode.pid) {
+                  return endorse(selectedNode.text);
+                }
+                socket.emit('posts.getRawPost', toPid, function (err, post) {
+                  if (err) {
+                    return alerts.error(err);
+                  }
+      
+                  endorse(post);
+                });
+              });
+            }
     async function onReplyClicked(button, tid) {
         const selectedNode = await getSelectedNode();
 

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -81,6 +81,7 @@
         <span class="post-tools">
             <a component="post/reply" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:reply]]</a>
             <a component="post/quote" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:quote]]</a>
+            <a component="post/endorse" href="#" class="no-select <!-- IF !privileges.topics:reply -->hidden<!-- ENDIF !privileges.topics:reply -->">[[topic:endorse]]</a>
         </span>
 
         <!-- IF !reputation:disabled -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -9,7 +9,7 @@
     <small class="pull-left">
         <strong>
             <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
-            <span style="color:green">~~ this response is endorsed by an administrator ~~</span>
+            <span style="color:green">~~ This response is endorsed by an administrator ~~</span>
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -9,6 +9,7 @@
     <small class="pull-left">
         <strong>
             <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+            <span style="color:green">~~ this response is endorsed by an administrator ~~</span>
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->


### PR DESCRIPTION
Resolves Issue #30 

This request adds a status indicator saying "~~ This response is endorsed by an administrator ~~" after the user's display name for posts. Currently, this indicator will appear on all posts as the endorse functionality has not yet been implemented.

Next steps:
1. Add a status attribute to posts that have been endorsed
2. Track all posts that have this endorsed status as "true"
3. Update this indicator to only appear for those posts that have been endorsed

These steps depend on having a functional endorse button as well that can toggle the endorse status of posts