### PR TITLE
Add fairness evaluations to Jupyter Notebook

### DIFF
--- a/.ipynb_checkpoints/Project4ModelAnalysis-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Project4ModelAnalysis-checkpoint.ipynb
@@ -1,0 +1,478 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "QMBbaCsT2P0O"
+   },
+   "source": [
+    "IMPORTING LIBRARIES"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "phh1sq7HDRFt",
+    "outputId": "9e688016-12d7-4828-a0da-bf4da858a4d4"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: scikit-learn==1.2.1 in /Users/meimeiwang/miniconda3/lib/python3.8/site-packages (1.2.1)\n",
+      "Requirement already satisfied: scipy>=1.3.2 in /Users/meimeiwang/miniconda3/lib/python3.8/site-packages (from scikit-learn==1.2.1) (1.7.1)\n",
+      "Requirement already satisfied: threadpoolctl>=2.0.0 in /Users/meimeiwang/miniconda3/lib/python3.8/site-packages (from scikit-learn==1.2.1) (3.1.0)\n",
+      "Requirement already satisfied: numpy>=1.17.3 in /Users/meimeiwang/miniconda3/lib/python3.8/site-packages (from scikit-learn==1.2.1) (1.20.3)\n",
+      "Requirement already satisfied: joblib>=1.1.1 in /Users/meimeiwang/miniconda3/lib/python3.8/site-packages (from scikit-learn==1.2.1) (1.2.0)\n",
+      "\u001b[33mWARNING: You are using pip version 21.2.4; however, version 23.0.1 is available.\n",
+      "You should consider upgrading via the '/Users/meimeiwang/miniconda3/bin/python -m pip install --upgrade pip' command.\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install scikit-learn==1.2.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Bcf2TGssBF75",
+    "outputId": "f8b0b867-2f86-440b-8444-224c2f14e7d2"
+   },
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'google.colab'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/_h/yq1hn_md3b31yw3nc5wzzzmr0000gq/T/ipykernel_6888/1408506528.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mgoogle\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcolab\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mdrive\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mdrive\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmount\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'/content/drive'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'google.colab'"
+     ]
+    }
+   ],
+   "source": [
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "tmuyyACQLtKK"
+   },
+   "outputs": [],
+   "source": [
+    "!cp drive/MyDrive/17313/predict.py .\n",
+    "!cp drive/MyDrive/17313/model.pkl .\n",
+    "!cp drive/MyDrive/17313/requirements.txt ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "8286jexMozfw"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import predict as pred\n",
+    "\n",
+    "from sklearn import metrics\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9FvxVx7Y2fix"
+   },
+   "source": [
+    "INSTALLING DEPENDENCIES (IF NOT DONE YET)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "_qaycJfs2ewz",
+    "outputId": "357bcea2-37c4-4d7e-adcf-e5e9f3a4ec1b"
+   },
+   "outputs": [],
+   "source": [
+    "pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MGcKNrbz2KbD"
+   },
+   "source": [
+    "LOADING DATASET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "6PqDa-Pcr8Hr",
+    "outputId": "39401eee-aa36-47b9-ffa1-edf2a311693b"
+   },
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('drive/MyDrive/17313/student_data.csv')\n",
+    "print(df.head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "E-rIkpousSxK"
+   },
+   "source": [
+    "PLOTTING DISTRIBUTION OF FEATURES IN TEST DATASET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 472
+    },
+    "id": "2Wh8gtG2sH6E",
+    "outputId": "64bb2e68-51bb-4e69-94d8-aa32349b33d6"
+   },
+   "outputs": [],
+   "source": [
+    "#Gender\n",
+    "gender_counts = df['Gender'].value_counts()\n",
+    "plt.bar(gender_counts.index, gender_counts.values)\n",
+    "\n",
+    "plt.title('Count by Gender')\n",
+    "plt.xlabel('Gender')\n",
+    "plt.ylabel('Count')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 472
+    },
+    "id": "nhdF8kPduFe-",
+    "outputId": "7402bb37-6354-4fd8-f5b7-8a486adde5ae"
+   },
+   "outputs": [],
+   "source": [
+    "#Age\n",
+    "plt.title('Count by Age')\n",
+    "plt.xlabel('Age')\n",
+    "plt.ylabel('Count')\n",
+    "\n",
+    "plt.hist(df[\"Age\"])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 433
+    },
+    "id": "phAizAcZvf1-",
+    "outputId": "a73972f5-c240-4800-f173-697465a89359"
+   },
+   "outputs": [],
+   "source": [
+    "#Majors\n",
+    "major_counts = df[\"Major\"].value_counts()\n",
+    "\n",
+    "plt.pie(major_counts, labels=major_counts.index, autopct='%1.1f%%')\n",
+    "plt.title('Majors Distribution')\n",
+    "plt.axis('equal')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 472
+    },
+    "id": "RIUeulifwyHn",
+    "outputId": "9cd44ae8-f8af-482d-80eb-c9237706090b"
+   },
+   "outputs": [],
+   "source": [
+    "#GPA\n",
+    "plt.title('Count by GPA')\n",
+    "plt.xlabel('GPA')\n",
+    "plt.ylabel('Count')\n",
+    "\n",
+    "plt.hist(df[\"GPA\"])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 435
+    },
+    "id": "XNmdehkD1qVM",
+    "outputId": "9bce6fd9-3ac6-4b92-be78-65add762aa12"
+   },
+   "outputs": [],
+   "source": [
+    "#Extra Curricular\n",
+    "ec_counts = df[\"Extra Curricular\"].value_counts()\n",
+    "\n",
+    "plt.pie(ec_counts, labels=ec_counts.index, autopct='%1.1f%%')\n",
+    "plt.title('Extra Curricular Distribution')\n",
+    "plt.axis('equal')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 472
+    },
+    "id": "ZiIoyESizA5t",
+    "outputId": "7073075a-db56-4ea9-e42a-3cafe0df0c1d"
+   },
+   "outputs": [],
+   "source": [
+    "#Num Programming Languages\n",
+    "\n",
+    "num_lan_counts = df[\"Num Programming Languages\"].value_counts()\n",
+    "plt.bar(num_lan_counts.index, num_lan_counts.values)\n",
+    "\n",
+    "plt.title('Count by Num Programming Languages')\n",
+    "plt.xlabel('Num Programming Languages')\n",
+    "plt.ylabel('Count')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 472
+    },
+    "id": "W3LN9NFEzH3h",
+    "outputId": "d70f2ff3-2a88-4fd8-80d9-6c9b0273bc2a"
+   },
+   "outputs": [],
+   "source": [
+    "#Num Past Internships\n",
+    "#order = [0, 1, 2, 3, 4]\n",
+    "\n",
+    "num_past_int = df[\"Num Past Internships\"].value_counts()\n",
+    "plt.bar(num_past_int.index, num_past_int.values)\n",
+    "\n",
+    "plt.title('Count by Num Past Internships')\n",
+    "plt.xlabel('Num Past Internships')\n",
+    "plt.ylabel('Count')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 472
+    },
+    "id": "3_vX1jUyzgK_",
+    "outputId": "e6d8c1a4-2474-4c68-ecd3-763ce2896879"
+   },
+   "outputs": [],
+   "source": [
+    "#Good Candidate\n",
+    "\n",
+    "good_can = df[\"Good Candidate\"].value_counts()\n",
+    "plt.bar(good_can.index, good_can.values)\n",
+    "\n",
+    "plt.title('Count by Good Candidate')\n",
+    "plt.xlabel('Good Candidate')\n",
+    "plt.ylabel('Count')\n",
+    "\n",
+    "plt.xticks([0, 1])  # Set x-tick marks to only display values of 0 and 1\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "atcPuCPZ157C"
+   },
+   "source": [
+    "PREDICTING OUTPUT OF TEST DATASET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "8xpyqySe33vI"
+   },
+   "outputs": [],
+   "source": [
+    "df_X = df.iloc[: , :-1]\n",
+    "df_Y = df.iloc[: , -1:]\n",
+    "\n",
+    "#converting X to a list of dicts\n",
+    "dict_list_X = df.to_dict(orient=\"records\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "w5ESQx3O5Q1i"
+   },
+   "outputs": [],
+   "source": [
+    "#predicting output of test dataset based on model\n",
+    "predList = []\n",
+    "for student in dict_list_X:\n",
+    "  res = pred.predict(student)[\"good_employee\"]\n",
+    "  predList.append(res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jMAana3R2F6K"
+   },
+   "source": [
+    "RESULT EVALUATION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TKOo_Zh_5210"
+   },
+   "outputs": [],
+   "source": [
+    "#accuracy\n",
+    "#check if this is backwards\n",
+    "accuracy = metrics.accuracy_score(df_Y, predList)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "HGD1DLrpNVl9",
+    "outputId": "dabcf653-3752-48c6-ee2a-637eee821561"
+   },
+   "outputs": [],
+   "source": [
+    "accuracy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6TzK9oUn6JLR"
+   },
+   "outputs": [],
+   "source": [
+    "#confusion matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 453
+    },
+    "id": "p8CCjczg6llx",
+    "outputId": "93a5f179-5c55-408f-aa2a-4ee71c33069b"
+   },
+   "outputs": [],
+   "source": [
+    "confusion_matrix = metrics.confusion_matrix(df_Y, predList)\n",
+    "\n",
+    "cm_display = metrics.ConfusionMatrixDisplay(confusion_matrix = confusion_matrix, display_labels = [False, True])\n",
+    "\n",
+    "cm_display.plot()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/Project4ModelAnalysis.ipynb
+++ b/Project4ModelAnalysis.ipynb
@@ -11,13 +11,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 58,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "phh1sq7HDRFt",
-        "outputId": "9e688016-12d7-4828-a0da-bf4da858a4d4"
+        "outputId": "0270de8b-4b0b-46bc-a724-d1d50b98b104"
       },
       "outputs": [
         {
@@ -25,19 +25,11 @@
           "name": "stdout",
           "text": [
             "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Collecting scikit-learn==1.2.1\n",
-            "  Downloading scikit_learn-1.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (9.6 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m9.6/9.6 MB\u001b[0m \u001b[31m35.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: numpy>=1.17.3 in /usr/local/lib/python3.9/dist-packages (from scikit-learn==1.2.1) (1.22.4)\n",
+            "Requirement already satisfied: scikit-learn==1.2.1 in /usr/local/lib/python3.9/dist-packages (1.2.1)\n",
             "Requirement already satisfied: scipy>=1.3.2 in /usr/local/lib/python3.9/dist-packages (from scikit-learn==1.2.1) (1.10.1)\n",
+            "Requirement already satisfied: joblib>=1.1.1 in /usr/local/lib/python3.9/dist-packages (from scikit-learn==1.2.1) (1.2.0)\n",
             "Requirement already satisfied: threadpoolctl>=2.0.0 in /usr/local/lib/python3.9/dist-packages (from scikit-learn==1.2.1) (3.1.0)\n",
-            "Requirement already satisfied: joblib>=1.1.1 in /usr/local/lib/python3.9/dist-packages (from scikit-learn==1.2.1) (1.1.1)\n",
-            "Installing collected packages: scikit-learn\n",
-            "  Attempting uninstall: scikit-learn\n",
-            "    Found existing installation: scikit-learn 1.2.2\n",
-            "    Uninstalling scikit-learn-1.2.2:\n",
-            "      Successfully uninstalled scikit-learn-1.2.2\n",
-            "Successfully installed scikit-learn-1.2.1\n"
+            "Requirement already satisfied: numpy>=1.17.3 in /usr/local/lib/python3.9/dist-packages (from scikit-learn==1.2.1) (1.24.2)\n"
           ]
         }
       ],
@@ -47,20 +39,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 59,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Bcf2TGssBF75",
-        "outputId": "f8b0b867-2f86-440b-8444-224c2f14e7d2"
+        "outputId": "cc0e4eaf-db74-45ad-a4e3-db276777a1a1"
       },
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Mounted at /content/drive\n"
+            "Drive already mounted at /content/drive; to attempt to forcibly remount, call drive.mount(\"/content/drive\", force_remount=True).\n"
           ]
         }
       ],
@@ -79,12 +71,12 @@
       "metadata": {
         "id": "tmuyyACQLtKK"
       },
-      "execution_count": null,
+      "execution_count": 60,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 61,
       "metadata": {
         "id": "8286jexMozfw"
       },
@@ -109,13 +101,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 62,
       "metadata": {
+        "id": "_qaycJfs2ewz",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "_qaycJfs2ewz",
-        "outputId": "357bcea2-37c4-4d7e-adcf-e5e9f3a4ec1b"
+        "outputId": "b0a932ea-14da-4db3-f670-a4f07f99fede"
       },
       "outputs": [
         {
@@ -123,47 +115,17 @@
           "name": "stdout",
           "text": [
             "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Collecting joblib==1.2.0\n",
-            "  Downloading joblib-1.2.0-py3-none-any.whl (297 kB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m298.0/298.0 KB\u001b[0m \u001b[31m5.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting numpy==1.24.2\n",
-            "  Downloading numpy-1.24.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m17.3/17.3 MB\u001b[0m \u001b[31m24.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting pandas==1.5.3\n",
-            "  Downloading pandas-1.5.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.2/12.2 MB\u001b[0m \u001b[31m51.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting pydantic==1.10.6\n",
-            "  Downloading pydantic-1.10.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.2/3.2 MB\u001b[0m \u001b[31m43.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: python-dateutil==2.8.2 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 5)) (2.8.2)\n",
+            "Requirement already satisfied: joblib==1.2.0 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 1)) (1.2.0)\n",
+            "Requirement already satisfied: numpy==1.24.2 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 2)) (1.24.2)\n",
+            "Requirement already satisfied: pandas==1.5.3 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 3)) (1.5.3)\n",
+            "Requirement already satisfied: pydantic==1.10.6 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 4)) (1.10.6)\n",
+            "Requirement already satisfied: python-dateutil==2.8.2 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 5)) (2.8.2)\n",
             "Requirement already satisfied: pytz==2022.7.1 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 6)) (2022.7.1)\n",
             "Requirement already satisfied: scikit-learn==1.2.1 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 7)) (1.2.1)\n",
             "Requirement already satisfied: scipy==1.10.1 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 8)) (1.10.1)\n",
             "Requirement already satisfied: six==1.16.0 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 9)) (1.16.0)\n",
             "Requirement already satisfied: threadpoolctl==3.1.0 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 10)) (3.1.0)\n",
-            "Requirement already satisfied: typing_extensions==4.5.0 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 11)) (4.5.0)\n",
-            "Installing collected packages: pydantic, numpy, joblib, pandas\n",
-            "  Attempting uninstall: pydantic\n",
-            "    Found existing installation: pydantic 1.10.7\n",
-            "    Uninstalling pydantic-1.10.7:\n",
-            "      Successfully uninstalled pydantic-1.10.7\n",
-            "  Attempting uninstall: numpy\n",
-            "    Found existing installation: numpy 1.22.4\n",
-            "    Uninstalling numpy-1.22.4:\n",
-            "      Successfully uninstalled numpy-1.22.4\n",
-            "  Attempting uninstall: joblib\n",
-            "    Found existing installation: joblib 1.1.1\n",
-            "    Uninstalling joblib-1.1.1:\n",
-            "      Successfully uninstalled joblib-1.1.1\n",
-            "  Attempting uninstall: pandas\n",
-            "    Found existing installation: pandas 1.4.4\n",
-            "    Uninstalling pandas-1.4.4:\n",
-            "      Successfully uninstalled pandas-1.4.4\n",
-            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-            "tensorflow 2.12.0 requires numpy<1.24,>=1.22, but you have numpy 1.24.2 which is incompatible.\n",
-            "pandas-profiling 3.2.0 requires joblib~=1.1.0, but you have joblib 1.2.0 which is incompatible.\n",
-            "numba 0.56.4 requires numpy<1.24,>=1.18, but you have numpy 1.24.2 which is incompatible.\u001b[0m\u001b[31m\n",
-            "\u001b[0mSuccessfully installed joblib-1.2.0 numpy-1.24.2 pandas-1.5.3 pydantic-1.10.6\n"
+            "Requirement already satisfied: typing_extensions==4.5.0 in /usr/local/lib/python3.9/dist-packages (from -r requirements.txt (line 11)) (4.5.0)\n"
           ]
         }
       ],
@@ -182,13 +144,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 63,
       "metadata": {
+        "id": "6PqDa-Pcr8Hr",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "6PqDa-Pcr8Hr",
-        "outputId": "39401eee-aa36-47b9-ffa1-edf2a311693b"
+        "outputId": "ff267aed-0744-4f5f-c63b-8a860093276c"
       },
       "outputs": [
         {
@@ -234,14 +196,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 64,
       "metadata": {
+        "id": "2Wh8gtG2sH6E",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 472
         },
-        "id": "2Wh8gtG2sH6E",
-        "outputId": "64bb2e68-51bb-4e69-94d8-aa32349b33d6"
+        "outputId": "cc89452f-48c1-4660-f6f6-6f527be975ff"
       },
       "outputs": [
         {
@@ -269,14 +231,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 65,
       "metadata": {
+        "id": "nhdF8kPduFe-",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 472
         },
-        "id": "nhdF8kPduFe-",
-        "outputId": "7402bb37-6354-4fd8-f5b7-8a486adde5ae"
+        "outputId": "e18e1adc-14a7-4197-cdb2-7d5349c2684b"
       },
       "outputs": [
         {
@@ -302,14 +264,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 66,
       "metadata": {
+        "id": "phAizAcZvf1-",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 433
         },
-        "id": "phAizAcZvf1-",
-        "outputId": "a73972f5-c240-4800-f173-697465a89359"
+        "outputId": "8b31e99e-54c7-4ca2-d189-2f9e8426759b"
       },
       "outputs": [
         {
@@ -335,14 +297,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 67,
       "metadata": {
+        "id": "RIUeulifwyHn",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 472
         },
-        "id": "RIUeulifwyHn",
-        "outputId": "9cd44ae8-f8af-482d-80eb-c9237706090b"
+        "outputId": "9d229b77-ffd5-4da8-cc00-4f26815fa395"
       },
       "outputs": [
         {
@@ -368,14 +330,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 68,
       "metadata": {
         "id": "XNmdehkD1qVM",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 435
         },
-        "outputId": "9bce6fd9-3ac6-4b92-be78-65add762aa12"
+        "outputId": "43cc619a-88d3-4dc8-f2e9-27df7ba222ae"
       },
       "outputs": [
         {
@@ -401,14 +363,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 69,
       "metadata": {
+        "id": "ZiIoyESizA5t",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 472
         },
-        "id": "ZiIoyESizA5t",
-        "outputId": "7073075a-db56-4ea9-e42a-3cafe0df0c1d"
+        "outputId": "9a599f21-300e-44c0-a6bd-5d0851ab073f"
       },
       "outputs": [
         {
@@ -437,14 +399,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 70,
       "metadata": {
+        "id": "W3LN9NFEzH3h",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 472
         },
-        "id": "W3LN9NFEzH3h",
-        "outputId": "d70f2ff3-2a88-4fd8-80d9-6c9b0273bc2a"
+        "outputId": "9fcfd9b2-f2fb-4eb2-d62d-01e3abeeba9b"
       },
       "outputs": [
         {
@@ -474,14 +436,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
+      "execution_count": 71,
       "metadata": {
+        "id": "3_vX1jUyzgK_",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 472
         },
-        "id": "3_vX1jUyzgK_",
-        "outputId": "e6d8c1a4-2474-4c68-ecd3-763ce2896879"
+        "outputId": "7b53448b-a026-47d9-d0dc-7ab2c27701ae"
       },
       "outputs": [
         {
@@ -520,7 +482,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
+      "execution_count": 72,
       "metadata": {
         "id": "8xpyqySe33vI"
       },
@@ -535,7 +497,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
+      "execution_count": 73,
       "metadata": {
         "id": "w5ESQx3O5Q1i"
       },
@@ -559,7 +521,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": 74,
       "metadata": {
         "id": "TKOo_Zh_5210"
       },
@@ -580,9 +542,9 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "dabcf653-3752-48c6-ee2a-637eee821561"
+        "outputId": "7ff41a3c-f472-4603-a7e8-56d61d338f36"
       },
-      "execution_count": 27,
+      "execution_count": 75,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -592,13 +554,13 @@
             ]
           },
           "metadata": {},
-          "execution_count": 27
+          "execution_count": 75
         }
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 76,
       "metadata": {
         "id": "6TzK9oUn6JLR"
       },
@@ -609,14 +571,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
+      "execution_count": 77,
       "metadata": {
         "id": "p8CCjczg6llx",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 453
         },
-        "outputId": "93a5f179-5c55-408f-aa2a-4ee71c33069b"
+        "outputId": "3556c479-36bc-4dc4-ba77-b551d80373f6"
       },
       "outputs": [
         {
@@ -638,6 +600,265 @@
         "cm_display.plot()\n",
         "plt.show()"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "FAIRNESS EVALUATION"
+      ],
+      "metadata": {
+        "id": "JceQxVajJGA6"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# divide the dataset based on gender\n",
+        "df_female = df[df['Gender'] == 'F'] \n",
+        "df_male = df[df['Gender'] == 'M'] "
+      ],
+      "metadata": {
+        "id": "AkSwdWrBIR1a"
+      },
+      "execution_count": 78,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "df_female_X = df_female.iloc[: , :-1]\n",
+        "df_female_Y = df_female.iloc[: , -1:]\n",
+        "\n",
+        "#converting X to a list of dicts\n",
+        "female_dict_list_X = df_female.to_dict(orient=\"records\")\n",
+        "\n",
+        "df_male_X = df_male.iloc[: , :-1]\n",
+        "df_male_Y = df_male.iloc[: , -1:]\n",
+        "\n",
+        "#converting X to a list of dicts\n",
+        "male_dict_list_X = df_male.to_dict(orient=\"records\")\n"
+      ],
+      "metadata": {
+        "id": "-0OmSCTZLloQ"
+      },
+      "execution_count": 79,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#predicting output of test dataset based on model\n",
+        "femalePredList = []\n",
+        "for student in female_dict_list_X:\n",
+        "  res = pred.predict(student)[\"good_employee\"]\n",
+        "  femalePredList.append(res)\n",
+        "\n",
+        "#predicting output of test dataset based on model\n",
+        "malePredList = []\n",
+        "for student in male_dict_list_X:\n",
+        "  res = pred.predict(student)[\"good_employee\"]\n",
+        "  malePredList.append(res)"
+      ],
+      "metadata": {
+        "id": "4DoATW8BL0oL"
+      },
+      "execution_count": 80,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# confusion matrix for female group\n",
+        "confusion_matrix = metrics.confusion_matrix(df_female_Y, femalePredList)\n",
+        "\n",
+        "cm_display = metrics.ConfusionMatrixDisplay(confusion_matrix = confusion_matrix, display_labels = [False, True])\n",
+        "\n",
+        "cm_display.plot()\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 455
+        },
+        "id": "jZ7PvI6UMqwI",
+        "outputId": "40d00827-514c-48aa-82f7-e53b9d8f9387"
+      },
+      "execution_count": 84,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 2 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhUAAAG2CAYAAADIhHSjAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA77ElEQVR4nO3deVhV5fr/8c9GcIPABjEFUTSctZzteKhMLUpt0rT62qHUMhuUTD2O38Ipk7LJMJOm49DRbzZpaSf7mZ4000wxrUxxTHFAOxkQKONevz/M3dmhxnY/gDver+taV+61nrXWvYrcN/czLJtlWZYAAAC85FfZAQAAgD8HkgoAAGAESQUAADCCpAIAABhBUgEAAIwgqQAAAEaQVAAAACNIKgAAgBEkFQAAwAiSCgAAYARJBQAAPmzt2rW65ZZbFB0dLZvNpqVLl56z7UMPPSSbzaaZM2e67T9x4oQSEhLkcDgUHh6uwYMHKzc31+NYSCoAAPBheXl5atu2rWbPnn3edkuWLNGXX36p6OjoUscSEhK0fft2rVy5UsuXL9fatWv1wAMPeByLv8dnAACAi0avXr3Uq1ev87Y5fPiwHnnkEX3yySe66aab3I7t2LFDK1as0KZNm9SpUydJ0qxZs3TjjTfq2WefPWsSci4kFWXgdDp15MgRhYaGymazVXY4AAAPWZalX375RdHR0fLzK78ifX5+vgoLC72+jmVZpb5v7Ha77Ha7x9dyOp265557NGbMGF122WWljm/YsEHh4eGuhEKS4uPj5efnp40bN+q2224r871IKsrgyJEjiomJqewwAABeysjIUP369cvl2vn5+YptGKLM4yVeXyskJKTUmIZJkyZp8uTJHl/r6aeflr+/v4YPH37W45mZmapTp47bPn9/f0VERCgzM9Oje5FUlEFoaKgk6cCWS+UIYRgK/pxua9a6skMAyk2xirRO/3L9fV4eCgsLlXm8RAfSLpUj9MK/K3J+caphxx+UkZEhh8Ph2n8hVYq0tDS9+OKL2rJlS4VU2kkqyuDMfwhHiJ9XPyjAxczfFlDZIQDlxzr9j4r4Yg0JtSkk9MLv49Sv3zkOh1tScSE+//xzHT9+XA0aNHDtKykp0d///nfNnDlTP/zwg6KionT8+HG384qLi3XixAlFRUV5dD+SCgAADCqxnCqxvDvflHvuuUfx8fFu+3r06KF77rlH9957ryQpLi5OWVlZSktLU8eOHSVJq1evltPpVOfOnT26H0kFAAAGOWXJqQvPKjw9Nzc3V3v27HF93r9/v7Zu3aqIiAg1aNBAtWrVcmsfEBCgqKgoNW/eXJLUsmVL9ezZU0OGDFFqaqqKioqUmJio/v37ezTzQ2KdCgAAfNrmzZvVvn17tW/fXpI0atQotW/fXhMnTizzNRYuXKgWLVrouuuu04033qirr75ar776qsexUKkAAMAgp5zypgPD07O7desmyyp7deOHH34otS8iIkKLFi3y6L5nQ1IBAIBBJZalEg++5M92vq+i+wMAABhBpQIAAIMqeqDmxYSkAgAAg5yyVFJFkwq6PwAAgBFUKgAAMIjuDwAAYASzPwAAALxEpQIAAIOcv27enO+rSCoAADCoxMvZH96cW9lIKgAAMKjEkpdvKTUXS0VjTAUAADCCSgUAAAYxpgIAABjhlE0lsnl1vq+i+wMAABhBpQIAAIOc1unNm/N9FUkFAAAGlXjZ/eHNuZWN7g8AAGAElQoAAAyqypUKkgoAAAxyWjY5LS9mf3hxbmWj+wMAABhBpQIAAIPo/gAAAEaUyE8lXnQElBiMpaKRVAAAYJDl5ZgKizEVAACgqqNSAQCAQYypAAAARpRYfiqxvBhT4cPLdNP9AQAAjKBSAQCAQU7Z5PTid3anfLdUQVIBAIBBVXlMBd0fAADACCoVAAAY5P1ATbo/AACAzoyp8OKFYnR/AACAqo5KBQAABjm9fPcHsz8AAIAkxlQAAABDnPKrsutUMKYCAAAYQaUCAACDSiybSrx4fbk351Y2kgoAAAwq8XKgZgndHwAAoKqjUgEAgEFOy09OL2Z/OJn9AQAAJLo/AACAj1q7dq1uueUWRUdHy2azaenSpa5jRUVFGjdunFq3bq3g4GBFR0drwIABOnLkiNs1Tpw4oYSEBDkcDoWHh2vw4MHKzc31OBaSCgAADHLqtxkgF7I5PbxfXl6e2rZtq9mzZ5c6dvLkSW3ZskVJSUnasmWL3n//faWnp+vWW291a5eQkKDt27dr5cqVWr58udauXasHHnjA42en+wMAAIO8X/zKs3N79eqlXr16nfVYWFiYVq5c6bbvpZde0l/+8hcdPHhQDRo00I4dO7RixQpt2rRJnTp1kiTNmjVLN954o5599llFR0eXORYqFQAAXIRycnLctoKCAiPXzc7Ols1mU3h4uCRpw4YNCg8PdyUUkhQfHy8/Pz9t3LjRo2uTVAAAYNCZd394s0lSTEyMwsLCXFtycrLXseXn52vcuHG666675HA4JEmZmZmqU6eOWzt/f39FREQoMzPTo+vT/QEAgEFO2eTUha+KeebcjIwM1xe/JNntdq/iKioq0p133inLsjRnzhyvrnUuJBUAABjk/VtKT5/rcDjckgpvnEkoDhw4oNWrV7tdNyoqSsePH3drX1xcrBMnTigqKsqj+9D9AQDAn9iZhGL37t369NNPVatWLbfjcXFxysrKUlpammvf6tWr5XQ61blzZ4/uRaUCAACDvF/8yrNzc3NztWfPHtfn/fv3a+vWrYqIiFDdunV1++23a8uWLVq+fLlKSkpc4yQiIiJUvXp1tWzZUj179tSQIUOUmpqqoqIiJSYmqn///h7N/JBIKgAAMMpp2eT04k2jnp67efNmde/e3fV51KhRkqSBAwdq8uTJ+vDDDyVJ7dq1czvv3//+t7p16yZJWrhwoRITE3XdddfJz89P/fr1U0pKisexk1QAAODDunXrJus87ws537EzIiIitGjRIq9jIakAAMAgp5fdH94snFXZSCoAADDI+7eU+m5S4buRAwCAiwqVCgAADCqRTSVeLH7lzbmVjaQCAACD6P4AAADwEpUKAAAMKpF3XRgl5kKpcCQVAAAYVJW7P0gqAAAwyNQLxXyR70YOAAAuKlQqAAAwyJJNTi/GVFhMKQUAABLdHwAAAF6jUgEAgEEV/erziwlJBQAABpV4+ZZSb86tbL4bOQAAuKhQqQAAwCC6PwAAgBFO+cnpRUeAN+dWNt+NHAAAXFSoVAAAYFCJZVOJF10Y3pxb2UgqAAAwiDEVAADACMvLt5RarKgJAACqOioVAAAYVCKbSrx4KZg351Y2kgoAAAxyWt6Ni3BaBoOpYHR/AAAAI3wyqZg3b57Cw8MrOwx46NsvgzVxQKzuan+ZekS30/qPw87Z9sVx9dUjup3ef6222/6cn6vpqWENdFuz1urborWeHxWjU3k++WOMKuh/Eo8p5V+7tGTXt1r8zXZN+sd+1W+cX9lhwTDnrwM1vdl8VaVGPmjQINlstlLbnj17KjMslJP8k35qdNkpJU4/dN52X3wcpp1pwaoVVVjq2NOJDXUgPUjJb+3V1Pn79O3GEM0cE1NeIQNGtYnL07J5l2jEzU01oX8jVfO3NP3/9skeVFLZocEgp2xeb76q0tOhnj176ujRo25bbGxsZYeFcnDFtb9o0LhMXdUr+5xt/nM0QC8/Xk/jZh+Q/+9G/Bzcbdfmfzs08rmDatHhpC7vnKeh0w5pzQfh+imT4UG4+D2W0Egr347QgV2B2vd9kJ4b0UCR9YvUtM2pyg4NMKLSkwq73a6oqCi37cUXX1Tr1q0VHBysmJgYDR06VLm5uee8xrZt29S9e3eFhobK4XCoY8eO2rx5s+v4unXr1KVLFwUFBSkmJkbDhw9XXl5eRTwePOB0SjOGN9DtDx/Xpc1Ll4R3bA5WSFixmrX97S/gDl1+kc1P2vl1cEWGChgR7Dhdofglq1olRwKTzqyo6c3mqyo9qTgbPz8/paSkaPv27Zo/f75Wr16tsWPHnrN9QkKC6tevr02bNiktLU3jx49XQECAJGnv3r3q2bOn+vXrp2+++UaLFy/WunXrlJiYWFGPgzJ6e3YdVatmqc/g/5z1+Ikf/RVeq9htXzV/KTS8WCeOU6mAb7HZLD005bC++6qGDqQHVXY4MKgqj6mo9L+Jly9frpCQENfnXr166Z133nF9vvTSSzVt2jQ99NBDevnll896jYMHD2rMmDFq0aKFJKlp06auY8nJyUpISNCIESNcx1JSUtS1a1fNmTNHgYGBpa5XUFCggoIC1+ecnByvnhF/bPc3QVr6em3N/iRdNt9N0oEyS5x+WA1b5OvvfZpUdiiAMZWeVHTv3l1z5sxxfQ4ODtann36q5ORk7dy5Uzk5OSouLlZ+fr5OnjypGjVqlLrGqFGjdP/99+vNN99UfHy87rjjDjVu3FjS6a6Rb775RgsXLnS1tyxLTqdT+/fvV8uWLUtdLzk5WVOmTCmHp8W5fLsxRFn/8dfdV1zm2ucssem1KdFa+lptLfjqe0XULlbWT+4/siXF0i9Z/oqoU/z7SwIXrWFPHlLn63P099sa6z9Hq1d2ODDMKS/f/cFAzQsXHBysJk2auLaCggLdfPPNatOmjd577z2lpaVp9uzZkqTCwtKzASRp8uTJ2r59u2666SatXr1arVq10pIlSyRJubm5evDBB7V161bXtm3bNu3evduVePzehAkTlJ2d7doyMjLK5+HhEt/vhFJXpWvOyt+2WlGFuv3h43py0V5JUstOecrN9tfub34rFW9dFyrLKbVozxgZ+AJLw548pCt7ZmvsHY11LMNe2QGhHFhezvywfDipqPRKxe+lpaXJ6XTqueeek5/f6Zzn7bff/sPzmjVrpmbNmmnkyJG66667NHfuXN12223q0KGDvv/+ezVpUvYSo91ul93O/+ymncrz05H9v/17zcyorr3fBSk0vFh16hfJEeE+rc7fX6pZp1gxTU53RTVoWqBO3XM0c3SMHnn6kEqKbJr9eD117Z2lWlFUKnDxS5x+WN1v+1mT743VqVw/1axdJEnK+6WaCvMr/Xc8GMJbSi8iTZo0UVFRkWbNmqVbbrlFX3zxhVJTU8/Z/tSpUxozZoxuv/12xcbG6tChQ9q0aZP69esnSRo3bpz++te/KjExUffff7+Cg4P1/fffa+XKlXrppZcq6rEgade2Ghp7+2/J3SuT60mSrr/zhEbPPFima4x76YBmP1Zf4+9sLJufdPWNWRo67XC5xAuYdsugnyRJz76/123/syNitPLtiMoICTDqoksq2rZtq+eff15PP/20JkyYoGuuuUbJyckaMGDAWdtXq1ZNP/30kwYMGKBjx47pkksuUd++fV1jItq0aaM1a9boscceU5cuXWRZlho3bqz/+Z//qcjHgqS2V+bqkyNby9x+wVffl9rnqFmiCS8fMBgVUHF6RLet7BBQAbydweHLsz9slmX58KtLKkZOTo7CwsL0865GcoT67n9s4Hx6RLer7BCAclNsFekzfaDs7Gw5HI5yuceZ74re/+8+BQRf+ADcorxCfXDDP8o11vLCNyQAADDiouv+AADAl3n7/g5fnlJKUgEAgEFVefYH3R8AAMAIkgoAAAw6U6nwZvPE2rVrdcsttyg6Olo2m01Lly51O25ZliZOnKi6desqKChI8fHx2r17t1ubEydOKCEhQQ6HQ+Hh4Ro8ePB5X+R5LiQVAAAYVNFJRV5entq2betaffr3ZsyYoZSUFKWmpmrjxo0KDg5Wjx49lJ//29ugExIStH37dq1cuVLLly/X2rVr9cADD3j87IypAADAh/Xq1Uu9evU66zHLsjRz5kw9/vjj6t27tyRpwYIFioyM1NKlS9W/f3/t2LFDK1as0KZNm9SpUydJ0qxZs3TjjTfq2WefVXR0dJljoVIBAIBBpioVOTk5btt/vz27rPbv36/MzEzFx8e79oWFhalz587asGGDJGnDhg0KDw93JRSSFB8fLz8/P23cuNGj+5FUAABgkCV5+UKx02JiYhQWFubakpOTPY4lMzNTkhQZGem2PzIy0nUsMzNTderUcTvu7++viIgIV5uyovsDAACDTE0pzcjIcFtR0xdedEmlAgCAi5DD4XDbLiSpiIqKkiQdO3bMbf+xY8dcx6KionT8+HG348XFxTpx4oSrTVmRVAAAYFBFz/44n9jYWEVFRWnVqlWufTk5Odq4caPi4uIkSXFxccrKylJaWpqrzerVq+V0OtW5c2eP7kf3BwAABlX0ipq5ubnas2eP6/P+/fu1detWRUREqEGDBhoxYoSmTZumpk2bKjY2VklJSYqOjlafPn0kSS1btlTPnj01ZMgQpaamqqioSImJierfv79HMz8kkgoAAHza5s2b1b17d9fnUaNGSZIGDhyoefPmaezYscrLy9MDDzygrKwsXX311VqxYoUCAwNd5yxcuFCJiYm67rrr5Ofnp379+iklJcXjWEgqAAAwqKIrFd26dZNlWec8brPZNHXqVE2dOvWcbSIiIrRo0SKP7ns2JBUAABhkWTZZXiQV3pxb2RioCQAAjKBSAQCAQWcWsfLmfF9FUgEAgEEVPabiYkL3BwAAMIJKBQAABlXlgZokFQAAGFSVuz9IKgAAMKgqVyoYUwEAAIygUgEAgEGWl90fvlypIKkAAMAgS9J5Vs0u0/m+iu4PAABgBJUKAAAMcsomGytqAgAAbzH7AwAAwEtUKgAAMMhp2WRj8SsAAOAty/Jy9ocPT/+g+wMAABhBpQIAAIOq8kBNkgoAAAwiqQAAAEZU5YGajKkAAABGUKkAAMCgqjz7g6QCAACDTicV3oypMBhMBaP7AwAAGEGlAgAAg5j9AQAAjLB+3bw531fR/QEAAIygUgEAgEF0fwAAADOqcP8HSQUAACZ5WamQD1cqGFMBAACMoFIBAIBBrKgJAACMqMoDNen+AAAARlCpAADAJMvm3WBLH65UkFQAAGBQVR5TQfcHAAAwgkoFAAAmsfjV+X344YdlvuCtt956wcEAAODrqvLsjzIlFX369CnTxWw2m0pKSryJBwAA+KgyJRVOp7O84wAA4M/Dh7swvOHVmIr8/HwFBgaaigUAAJ9Xlbs/PJ79UVJSoieeeEL16tVTSEiI9u3bJ0lKSkrSG2+8YTxAAAB8imVg80BJSYmSkpIUGxuroKAgNW7cWE888YSs/5qbalmWJk6cqLp16yooKEjx8fHavXu3lw9amsdJxZNPPql58+ZpxowZql69umv/5Zdfrtdff91ocAAA4PyefvppzZkzRy+99JJ27Nihp59+WjNmzNCsWbNcbWbMmKGUlBSlpqZq48aNCg4OVo8ePZSfn280Fo+TigULFujVV19VQkKCqlWr5trftm1b7dy502hwAAD4HpuBrezWr1+v3r1766abbtKll16q22+/XTfccIO++uorSaerFDNnztTjjz+u3r17q02bNlqwYIGOHDmipUuXGnje33icVBw+fFhNmjQptd/pdKqoqMhIUAAA+CxD3R85OTluW0FBwVlvd+WVV2rVqlXatWuXJGnbtm1at26devXqJUnav3+/MjMzFR8f7zonLCxMnTt31oYNG4w+usdJRatWrfT555+X2v/uu++qffv2RoICAKCqi4mJUVhYmGtLTk4+a7vx48erf//+atGihQICAtS+fXuNGDFCCQkJkqTMzExJUmRkpNt5kZGRrmOmeDz7Y+LEiRo4cKAOHz4sp9Op999/X+np6VqwYIGWL19uNDgAAHyOoRU1MzIy5HA4XLvtdvtZm7/99ttauHChFi1apMsuu0xbt27ViBEjFB0drYEDB3oRiOc8Tip69+6tZcuWaerUqQoODtbEiRPVoUMHLVu2TNdff315xAgAgO8w9JZSh8PhllScy5gxY1zVCklq3bq1Dhw4oOTkZA0cOFBRUVGSpGPHjqlu3bqu844dO6Z27dpdeJxncUHrVHTp0kUrV640GggAAPDcyZMn5efnPpqhWrVqroUrY2NjFRUVpVWrVrmSiJycHG3cuFEPP/yw0VguePGrzZs3a8eOHZJOj7Po2LGjsaAAAPBVFf3q81tuuUVPPvmkGjRooMsuu0xff/21nn/+ed13332STr9CY8SIEZo2bZqaNm2q2NhYJSUlKTo6usyv4Sgrj5OKQ4cO6a677tIXX3yh8PBwSVJWVpauvPJKvfXWW6pfv77RAAEA8CkV/JbSWbNmKSkpSUOHDtXx48cVHR2tBx98UBMnTnS1GTt2rPLy8vTAAw8oKytLV199tVasWGF8VWybZXmWE/Xs2VNZWVmaP3++mjdvLklKT0/XvffeK4fDoRUrVhgN8GKQk5OjsLAw/byrkRyhHk+YAXxCj+h2lR0CUG6KrSJ9pg+UnZ1dpnEKF+LMd0X9WVPkF3ThX9bOU/k69Mikco21vHhcqVizZo3Wr1/vSigkqXnz5po1a5a6dOliNDgAAHyOoYGavsjjpCImJuasi1yVlJQoOjraSFAAAPgqm3V68+Z8X+VxLf+ZZ57RI488os2bN7v2bd68WY8++qieffZZo8EBAOBzKviFYheTMlUqatasKZvtt3JMXl6eOnfuLH//06cXFxfL399f9913n/GRpAAAwDeUKamYOXNmOYcBAMCfBGMqzq+il/kEAMBnVfCU0ovJBS9+JUn5+fkqLCx02+dr018AAIAZHg/UzMvLU2JiourUqaPg4GDVrFnTbQMAoEqrwgM1PU4qxo4dq9WrV2vOnDmy2+16/fXXNWXKFEVHR2vBggXlESMAAL6jCicVHnd/LFu2TAsWLFC3bt107733qkuXLmrSpIkaNmyohQsXut7fDgAAqhaPKxUnTpxQo0aNJJ0eP3HixAlJ0tVXX621a9eajQ4AAF9zZvaHN5uP8jipaNSokfbv3y9JatGihd5++21JpysYZ14wBgBAVXVmRU1vNl/lcVJx7733atu2bZKk8ePHa/bs2QoMDNTIkSM1ZswY4wECAADf4PGYipEjR7r+HB8fr507dyotLU1NmjRRmzZtjAYHAIDPYZ2KC9ewYUM1bNjQRCwAAMCHlSmpSElJKfMFhw8ffsHBAADg62zy8i2lxiKpeGVKKl544YUyXcxms5FUAABQRZUpqTgz26Oqu2noAPn7B1Z2GEC5+PH9U5UdAlBuSk4WSAkfVMzNeKEYAAAwogoP1PR4SikAAMDZUKkAAMCkKlypIKkAAMAgb1fFrFIragIAAJzNBSUVn3/+ue6++27FxcXp8OHDkqQ333xT69atMxocAAA+pwq/+tzjpOK9995Tjx49FBQUpK+//loFBQWSpOzsbE2fPt14gAAA+BSSirKbNm2aUlNT9dprrykgIMC1/6qrrtKWLVuMBgcAAHyHxwM109PTdc0115TaHxYWpqysLBMxAQDgsxio6YGoqCjt2bOn1P5169apUaNGRoICAMBnnVlR05vNR3mcVAwZMkSPPvqoNm7cKJvNpiNHjmjhwoUaPXq0Hn744fKIEQAA31GFx1R43P0xfvx4OZ1OXXfddTp58qSuueYa2e12jR49Wo888kh5xAgAAHyAx0mFzWbTY489pjFjxmjPnj3Kzc1Vq1atFBISUh7xAQDgU6rymIoLXlGzevXqatWqlclYAADwfSzTXXbdu3eXzXbuQSSrV6/2KiAAAOCbPE4q2rVr5/a5qKhIW7du1XfffaeBAweaigsAAN/kZfdHlapUvPDCC2fdP3nyZOXm5nodEAAAPq0Kd38Ye6HY3XffrX/84x+mLgcAAHyMsVefb9iwQYGBgaYuBwCAb6rClQqPk4q+ffu6fbYsS0ePHtXmzZuVlJRkLDAAAHwRU0o9EBYW5vbZz89PzZs319SpU3XDDTcYCwwAAPgWj5KKkpIS3XvvvWrdurVq1qxZXjEBAAAf5NFAzWrVqumGG27gbaQAAJxLFX73h8ezPy6//HLt27evPGIBAMDnnRlT4c3mqzxOKqZNm6bRo0dr+fLlOnr0qHJyctw2AABQsQ4fPqy7775btWrVUlBQkFq3bq3Nmze7jluWpYkTJ6pu3boKCgpSfHy8du/ebTyOMicVU6dOVV5enm688UZt27ZNt956q+rXr6+aNWuqZs2aCg8PZ5wFAABShXZ9/Pzzz7rqqqsUEBCgjz/+WN9//72ee+45t+/kGTNmKCUlRampqdq4caOCg4PVo0cP5efne/WYv1fmgZpTpkzRQw89pH//+99GAwAA4E+lgtepePrppxUTE6O5c+e69sXGxv52OcvSzJkz9fjjj6t3796SpAULFigyMlJLly5V//79vQjWXZmTCss6/ZRdu3Y1dnMAAHB2vx9SYLfbZbfbS7X78MMP1aNHD91xxx1as2aN6tWrp6FDh2rIkCGSpP379yszM1Px8fGuc8LCwtS5c2dt2LDBaFLh0ZiK872dFAAAmBuoGRMTo7CwMNeWnJx81vvt27dPc+bMUdOmTfXJJ5/o4Ycf1vDhwzV//nxJUmZmpiQpMjLS7bzIyEjXMVM8WqeiWbNmf5hYnDhxwquAAADwaYa6PzIyMuRwOFy7z1alkCSn06lOnTpp+vTpkqT27dvru+++U2pqaoW/PdyjpGLKlCmlVtQEAADmORwOt6TiXOrWratWrVq57WvZsqXee+89SVJUVJQk6dixY6pbt66rzbFjx9SuXTtzAcvDpKJ///6qU6eO0QAAAPgzqeh3f1x11VVKT09327dr1y41bNhQ0ulBm1FRUVq1apUricjJydHGjRv18MMPX3igZ1HmpILxFAAAlEEFz/4YOXKkrrzySk2fPl133nmnvvrqK7366qt69dVXJZ3+/h4xYoSmTZumpk2bKjY2VklJSYqOjlafPn28CLQ0j2d/AACAi8cVV1yhJUuWaMKECZo6dapiY2M1c+ZMJSQkuNqMHTtWeXl5euCBB5SVlaWrr75aK1asUGBgoNFYypxUOJ1OozcGAOBPqYIrFZJ088036+abbz7ncZvNpqlTp2rq1KleBPbHPH71OQAAOLeKHlNxMSGpAADApEqoVFwsPH6hGAAAwNlQqQAAwKQqXKkgqQAAwKCqPKaC7g8AAGAElQoAAEyi+wMAAJhA9wcAAICXqFQAAGAS3R8AAMCIKpxU0P0BAACMoFIBAIBBtl83b873VSQVAACYVIW7P0gqAAAwiCmlAAAAXqJSAQCASXR/AAAAY3w4MfAG3R8AAMAIKhUAABhUlQdqklQAAGBSFR5TQfcHAAAwgkoFAAAG0f0BAADMoPsDAADAO1QqAAAwiO4PAABgRhXu/iCpAADApCqcVDCmAgAAGEGlAgAAgxhTAQAAzKD7AwAAwDtUKgAAMMhmWbJZF15u8ObcykZSAQCASXR/AAAAeIdKBQAABjH7AwAAmEH3BwAAgHeoVAAAYBDdHwAAwIwq3P1BUgEAgEFVuVLBmAoAAGAElQoAAEyqwt0fVCoAADDsTBfIhWzeeOqpp2Sz2TRixAjXvvz8fA0bNky1atVSSEiI+vXrp2PHjnl3o3MgqQAA4E9g06ZNeuWVV9SmTRu3/SNHjtSyZcv0zjvvaM2aNTpy5Ij69u1bLjGQVAAAYJJleb95KDc3VwkJCXrttddUs2ZN1/7s7Gy98cYbev7553XttdeqY8eOmjt3rtavX68vv/zS5FNLIqkAAMAob7o+/rsLJCcnx20rKCg45z2HDRumm266SfHx8W7709LSVFRU5La/RYsWatCggTZs2GD82UkqAAC4CMXExCgsLMy1JScnn7XdW2+9pS1btpz1eGZmpqpXr67w8HC3/ZGRkcrMzDQeM7M/AAAwydDsj4yMDDkcDtduu91eqmlGRoYeffRRrVy5UoGBgV7c1AwqFQAAGGRzer9JksPhcNvOllSkpaXp+PHj6tChg/z9/eXv7681a9YoJSVF/v7+ioyMVGFhobKystzOO3bsmKKioow/O5UKAAB81HXXXadvv/3Wbd+9996rFi1aaNy4cYqJiVFAQIBWrVqlfv36SZLS09N18OBBxcXFGY+HpAKV5tbuO3Rr9x2KuiRXkvTD4XAt+LC9vvo2RqHBBRrUZ4s6XXZYkbVylfVLoL7Y0lD/WNJReaeqV3LkQBmUWApdfFw11marWlaxSmr662T3cP1yR23JZpMk+WUVy/HmMQVuzZUtr0SFrYKVdX+USqJL/0YKH1KBi1+Fhobq8ssvd9sXHBysWrVqufYPHjxYo0aNUkREhBwOhx555BHFxcXpr3/9qxdBnt1FlVTYfv0f7VwmTZqkyZMnV0wwKHc/ngjWa+9eoUPHHLJJ6nHVbk0b/qkemNRHslm6JPykUhf/RQeOhCvyklyNHPCFaoWf1OSXr6vs0IE/FLLkPwr+5Gf9/Eg9FTewK2DPKdV86YicwdWUd1MtybJU66mDsvxt+ml8A1k1/BTy4U+6ZPIBHU9pIiuQ3mlfdbG9++OFF16Qn5+f+vXrp4KCAvXo0UMvv/yy2Zv86qJKKo4ePer68+LFizVx4kSlp6e79oWEhLj+bFmWSkpK5O9/UT0CPLBhWwO3z2+830m3dt+hVo2P61+fN9ek2b8lD0d+dOiN9zrpfx/4TH5+Tjmd/IWLi5s9/aTy/xKqgk6hkqSSOtVVsC5b1XefUp4k/6OFqr7rlI7NbKziBqcH2GU9WFdR96Ur6PNsnby+5nmujovaBa414Xa+Fz777DO3z4GBgZo9e7Zmz57t1XXL4qL6mzkqKsq1hYWFyWazuT7v3LlToaGh+vjjj9WxY0fZ7XatW7dOgwYNUp8+fdyuM2LECHXr1s312el0Kjk5WbGxsQoKClLbtm317rvvVuzD4bz8bE51/8teBdqLtX1vnbO2Ca5RqJP51Uko4BMKmteQ/Zs8+R85vbaA//58Vd9xUvntf/3lqOj0F4dV/b9+nv1ssgJsqr7zZEWHCxjhc7/mjx8/Xs8++6waNWrktmrY+SQnJ+uf//ynUlNT1bRpU61du1Z33323ateura5du5ZqX1BQ4LbISE5OjrH44S62/gnNfmyZqgeU6FRBgCa+FK8DR0r/d3WE5OueW77W8s+aV0KUgOdy+14iv1NO1Xlkz+lf35xSzt/q6FTXcElScT27ii8JkOOfx5T1ULQsu00hy36S/0/FKv65qFJjh3cutu6PiuRzScXUqVN1/fXXl7l9QUGBpk+frk8//dQ10rVRo0Zat26dXnnllbMmFcnJyZoyZYqxmHFuGUfDdP+k2xQSVKhrrtiv8fev1YinbnRLLGoEFuqpEf9PB47U1LwPOlRitEDZBa3PUdDaLP08sr6KYuwK2J+v8H9kyhkRoJPdwyV/m06Mi1H47COKHrBTlp9U0CZE+R1CfPotlVCVfkupzyUVnTp18qj9nj17dPLkyVKJSGFhodq3b3/WcyZMmKBRo0a5Pufk5CgmJsbzYPGHikuq6cjx04u77DpwiVpc+h/1u367np9/tSQpKLBQT//9E53MD1DSrOtUUkLXB3yDY36mcvteolNXh0mSihsGyv/HIoW8/+PppEJSUeMg/fh8Y9nySmQrtuQM81ftcftU2LjyFzECLoTPJRXBwcFun/38/GT9blBLUdFvpcPc3NPTFT/66CPVq1fPrd3ZFhI5s/9cx1C+bH6WAvxPr/xSI7BQM/6+QkXF1fRYyvUqKva5H1dUYX4Flmvq6BmW328LG7ntD64mS1K1IwUK2HtKOXedfVwRfAPdHz6sdu3a+u6779z2bd26VQEBAZKkVq1ayW636+DBg2ft6kDluf/2Tfrqm/o69lOIagQV6bq/7lW75kc19rmeqhFYqGdGr5C9erGmv9pNNQILVSOwUJKU/UugnBYVC1zcTl0RqtB3f1TxJQGnp5Tuy1fIsp908tpwV5vA9dlyOvxVckmAAg7mK+yNzNMzRtqFnPvCuPhV8uyPyuTzScW1116rZ555RgsWLFBcXJz++c9/6rvvvnN1bYSGhmr06NEaOXKknE6nrr76amVnZ+uLL76Qw+HQwIEDK/kJqq6aofmaMGStIsJOKu9Ude3LiNDY53oq7ft6atv8qFo1/lGStHDGO27n9R99p479FFoZIQNlln1/lKxFxxX+6lFVyzm9+FXeDTVPL371q2o/FytsbqaqZZeoJNxfJ7uFuR0HfI3PJxU9evRQUlKSxo4dq/z8fN13330aMGCA27KlTzzxhGrXrq3k5GTt27dP4eHh6tChg/73f/+3EiPHM3O7nPPYtvS66n7v4AqMBjDLCqqm7MF1lT247jnb5N1U6/RCWPhTqcrdHzbr9wMSUEpOTo7CwsJ0Zfxk+fszgAp/Tj8+eKqyQwDKTcnJAu1KeErZ2dlub/406cx3RVzPqfIPuPDviuKifG1YMbFcYy0vdEwDAAAjfL77AwCAi0lV7v4gqQAAwCSndXrz5nwfRVIBAIBJVXhFTcZUAAAAI6hUAABgkE1ejqkwFknFI6kAAMCkKryiJt0fAADACCoVAAAYxJRSAABgBrM/AAAAvEOlAgAAg2yWJZsXgy29ObeykVQAAGCS89fNm/N9FN0fAADACCoVAAAYRPcHAAAwowrP/iCpAADAJFbUBAAA8A6VCgAADGJFTQAAYAbdHwAAAN6hUgEAgEE25+nNm/N9FUkFAAAm0f0BAADgHSoVAACYxOJXAADAhKq8TDfdHwAAwAgqFQAAmFSFB2qSVAAAYJIlyZtpob6bU5BUAABgEmMqAAAAvESlAgAAkyx5OabCWCQVjqQCAACTqvBATbo/AADwYcnJybriiisUGhqqOnXqqE+fPkpPT3drk5+fr2HDhqlWrVoKCQlRv379dOzYMeOxkFQAAGCS08DmgTVr1mjYsGH68ssvtXLlShUVFemGG25QXl6eq83IkSO1bNkyvfPOO1qzZo2OHDmivn37evmgpdH9AQCAQRU9+2PFihVun+fNm6c6deooLS1N11xzjbKzs/XGG29o0aJFuvbaayVJc+fOVcuWLfXll1/qr3/96wXH+ntUKgAA+BPJzs6WJEVEREiS0tLSVFRUpPj4eFebFi1aqEGDBtqwYYPRe1OpAADAJEMDNXNyctx22+122e32857qdDo1YsQIXXXVVbr88sslSZmZmapevbrCw8Pd2kZGRiozM/PC4zwLKhUAAJh0JqnwZpMUExOjsLAw15acnPyHtx42bJi+++47vfXWW+X9lGdFpQIAgItQRkaGHA6H6/MfVSkSExO1fPlyrV27VvXr13ftj4qKUmFhobKystyqFceOHVNUVJTRmKlUAABgkqFKhcPhcNvOlVRYlqXExEQtWbJEq1evVmxsrNvxjh07KiAgQKtWrXLtS09P18GDBxUXF2f00alUAABgklOSzcvzPTBs2DAtWrRIH3zwgUJDQ13jJMLCwhQUFKSwsDANHjxYo0aNUkREhBwOhx555BHFxcUZnfkhkVQAAGBURU8pnTNnjiSpW7dubvvnzp2rQYMGSZJeeOEF+fn5qV+/fiooKFCPHj308ssvX3CM50JSAQCAD7PKkIQEBgZq9uzZmj17drnGQlIBAIBJVfjdHyQVAACY5LQkmxeJgdN3kwpmfwAAACOoVAAAYBLdHwAAwAwvkwr5blJB9wcAADCCSgUAACbR/QEAAIxwWvKqC4PZHwAAoKqjUgEAgEmW8/Tmzfk+iqQCAACTGFMBAACMYEwFAACAd6hUAABgEt0fAADACEteJhXGIqlwdH8AAAAjqFQAAGAS3R8AAMAIp1OSF2tNOH13nQq6PwAAgBFUKgAAMInuDwAAYEQVTiro/gAAAEZQqQAAwKQqvEw3SQUAAAZZllOWF28a9ebcykZSAQCASZblXbWBMRUAAKCqo1IBAIBJlpdjKny4UkFSAQCASU6nZPNiXIQPj6mg+wMAABhBpQIAAJPo/gAAACZYTqcsL7o/fHlKKd0fAADACCoVAACYRPcHAAAwwmlJtqqZVND9AQAAjKBSAQCASZYlyZt1Kny3UkFSAQCAQZbTkuVF94dFUgEAACT9uiImK2oCAABcMCoVAAAYRPcHAAAwowp3f5BUlMGZrLG4OL+SIwHKT8nJgsoOASg3Z36+K6IKUKwir9a+KlaRuWAqmM3y5TpLBTl06JBiYmIqOwwAgJcyMjJUv379crl2fn6+YmNjlZmZ6fW1oqKitH//fgUGBhqIrOKQVJSB0+nUkSNHFBoaKpvNVtnhVAk5OTmKiYlRRkaGHA5HZYcDGMXPd8WzLEu//PKLoqOj5edXfnMU8vPzVVhY6PV1qlev7nMJhUT3R5n4+fmVW2aL83M4HPyliz8tfr4rVlhYWLnfIzAw0CeTAVOYUgoAAIwgqQAAAEaQVOCiZLfbNWnSJNnt9soOBTCOn2/8WTFQEwAAGEGlAgAAGEFSAQAAjCCpAAAARpBU4KIyb948hYeHV3YYAIALQFKBcjFo0CDZbLZS2549eyo7NMCos/2c//c2efLkyg4RqDCsqIly07NnT82dO9dtX+3atSspGqB8HD161PXnxYsXa+LEiUpPT3ftCwkJcf3ZsiyVlJTI35+/evHnRKUC5cZutysqKspte/HFF9W6dWsFBwcrJiZGQ4cOVW5u7jmvsW3bNnXv3l2hoaFyOBzq2LGjNm/e7Dq+bt06denSRUFBQYqJidHw4cOVl5dXEY8HSJLbz3dYWJhsNpvr886dOxUaGqqPP/5YHTt2lN1u17p16zRo0CD16dPH7TojRoxQt27dXJ+dTqeSk5MVGxuroKAgtW3bVu+++27FPhzgIZIKVCg/Pz+lpKRo+/btmj9/vlavXq2xY8ees31CQoLq16+vTZs2KS0tTePHj1dAQIAkae/everZs6f69eunb775RosXL9a6deuUmJhYUY8DlMn48eP11FNPaceOHWrTpk2ZzklOTtaCBQuUmpqq7du3a+TIkbr77ru1Zs2aco4WuHDU4FBuli9f7lb67dWrl9555x3X50svvVTTpk3TQw89pJdffvms1zh48KDGjBmjFi1aSJKaNm3qOpacnKyEhASNGDHCdSwlJUVdu3bVnDlzqvRLfXBxmTp1qq6//voyty8oKND06dP16aefKi4uTpLUqFEjrVu3Tq+88oq6du1aXqECXiGpQLnp3r275syZ4/ocHBysTz/9VMnJydq5c6dycnJUXFys/Px8nTx5UjVq1Ch1jVGjRun+++/Xm2++qfj4eN1xxx1q3LixpNNdI998840WLlzoam9ZlpxOp/bv36+WLVuW/0MCZdCpUyeP2u/Zs0cnT54slYgUFhaqffv2JkMDjCKpQLkJDg5WkyZNXJ9/+OEH3XzzzXr44Yf15JNPKiIiQuvWrdPgwYNVWFh41qRi8uTJ+tvf/qaPPvpIH3/8sSZNmqS33npLt912m3Jzc/Xggw9q+PDhpc5r0KBBuT4b4Ing4GC3z35+fvr9GxKKiopcfz4zzuijjz5SvXr13NrxvhBczEgqUGHS0tLkdDr13HPPyc/v9HCet99++w/Pa9asmZo1a6aRI0fqrrvu0ty5c3XbbbepQ4cO+v77790SF8AX1K5dW999953bvq1bt7rGC7Vq1Up2u10HDx6kqwM+hYGaqDBNmjRRUVGRZs2apX379unNN99UamrqOdufOnVKiYmJ+uyzz3TgwAF98cUX2rRpk6tbY9y4cVq/fr0SExO1detW7d69Wx988AEDNXHRu/baa7V582YtWLBAu3fv1qRJk9ySjNDQUI0ePVojR47U/PnztXfvXm3ZskWzZs3S/PnzKzFy4PxIKlBh2rZtq+eff15PP/20Lr/8ci1cuFDJycnnbF+tWjX99NNPGjBggJo1a6Y777xTvXr10pQpUyRJbdq00Zo1a7Rr1y516dJF7du318SJExUdHV1RjwRckB49eigpKUljx47VFVdcoV9++UUDBgxwa/PEE08oKSlJycnJatmypXr27KmPPvpIsbGxlRQ18Md49TkAADCCSgUAADCCpAIAABhBUgEAAIwgqQAAAEaQVAAAACNIKgAAgBEkFQAAwAiSCsBHDBo0SH369HF97tatm+sNrRXps88+k81mU1ZW1jnb2Gw2LV26tMzXnDx5stq1a+dVXD/88INsNpu2bt3q1XUAXDiSCsALgwYNks1mk81mU/Xq1dWkSRNNnTpVxcXF5X7v999/X0888USZ2pYlEQAAb/FCMcBLPXv21Ny5c1VQUKB//etfGjZsmAICAjRhwoRSbQsLC1W9enUj942IiDByHQAwhUoF4CW73a6oqCg1bNhQDz/8sOLj4/Xhhx9K+q3L4sknn1R0dLSaN28uScrIyNCdd96p8PBwRUREqHfv3vrhhx9c1ywpKdGoUaMUHh6uWrVqaezYsaVelf377o+CggKNGzdOMTExstvtatKkid544w398MMP6t69uySpZs2astlsGjRokCTJ6XQqOTlZsbGxCgoKUtu2bfXuu++63edf//qXmjVrpqCgIHXv3t0tzrIaN26cmjVrpho1aqhRo0ZKSkpye9X3Ga+88opiYmJUo0YN3XnnncrOznY7/vrrr6tly5YKDAxUixYt9PLLL3scC4DyQ1IBGBYUFKTCwkLX51WrVik9PV0rV67U8uXLVVRUpB49eig0NFSff/65vvjiC4WEhKhnz56u85577jnNmzdP//jHP7Ru3TqdOHFCS5YsOe99BwwYoP/7v/9TSkqKduzYoVdeeUUhISGKiYnRe++9J0lKT0/X0aNH9eKLL0qSkpOTtWDBAqWmpmr79u0aOXKk7r77bq1Zs0bS6eSnb9++uuWWW7R161bdf//9Gj9+vMf/TkJDQzVv3jx9//33evHFF/Xaa6/phRdecGuzZ88evf3221q2bJlWrFihr7/+WkOHDnUdX7hwoSZOnKgnn3xSO3bs0PTp05WUlMRbO4GLiQXggg0cONDq3bu3ZVmW5XQ6rZUrV1p2u90aPXq063hkZKRVUFDgOufNN9+0mjdvbjmdTte+goICKygoyPrkk08sy7KsunXrWjNmzHAdLyoqsurXr++6l2VZVteuXa1HH33UsizLSk9PtyRZK1euPGuc//73vy1J1s8//+zal5+fb9WoUcNav369W9vBgwdbd911l2VZljVhwgSrVatWbsfHjRtX6lq/J8lasmTJOY8/88wzVseOHV2fJ02aZFWrVs06dOiQa9/HH39s+fn5WUePHrUsy7IaN25sLVq0yO06TzzxhBUXF2dZlmXt37/fkmR9/fXX57wvgPLFmArAS8uXL1dISIiKiorkdDr1t7/9TZMnT3Ydb926tds4im3btmnPnj0KDQ11u05+fr727t2r7OxsHT16VJ07d3Yd8/f3V6dOnUp1gZyxdetWVatWTV27di1z3Hv27NHJkyd1/fXXu+0vLCxU+/btJUk7duxwi0OS4uLiynyPMxYvXqyUlBTt3btXubm5Ki4ulsPhcGvToEED1atXz+0+TqdT6enpCg0N1d69ezV48GANGTLE1aa4uFhhYWEexwOgfJBUAF7q3r275syZo+rVqys6Olr+/u7/WwUHB7t9zs3NVceOHbVw4cJS16pdu/YFxRAUFOTxObm5uZKkjz76yO3LXDo9TsSUDRs2KCEhQVOmTFGPHj0UFhamt956S88995zHsb722mulkpxq1aoZixWAd0gqAC8FBwerSZMmZW7foUMHLV68WHXq1Cn12/oZdevW1caNG3XNNddIOv0beVpamjp06HDW9q1bt5bT6dSaNWsUHx9f6viZSklJSYlrX6tWrWS323Xw4MFzVjhatmzpGnR6xpdffvnHD/lf1q9fr4YNG+qxxx5z7Ttw4ECpdgcPHtSRI0cUHR3tuo+fn5+aN2+uyMhIRUdHa9++fUpISPDo/gAqDgM1gQqWkJCgSy65RL1799bnn3+u/fv367PPPtPw4cN16NAhSdKjjz6qp556SkuXLtXOnTs1dOjQ864xcemll2rgwIG67777tHTpUtc13377bUlSw4YNZbPZtHz5cv3444/Kzc1VaGioRo8erZEjR2r+/Pnau3evtmzZolmzZrkGPz700EPavXu3xowZo/T0dC1atEjz5s3z6HmbNm2qgwcP6q233tLevXuVkpJy1kGngYGBGjhwoLZt26bPP/9cw4cP15133qmoqChJ0pQpU5ScnKyUlBTt2rVL3377rebOnavnn3/eo3gAlB+SCqCC1ahRQ2vXrlWDBg3Ut29ftWzZUoMHD1Z+fr6rcvH3v/9d99xzjwYOHKi4uDiFhobqtttuO+9158yZo9tvv11Dhw5VixYtNGTIEOXl5UmS6tWrpylTpmj8+PGKjIxUYmKiJOmJJ55QUlKSkpOT1bJlS/Xs2VMfffSRYmNjJZ0e5/Dee+9p6dKlatu2rVJTUzV9+nSPnvfWW2/VyJEjlZiYqHbt2mn9+vVKSkoq1a5Jkybq27evbrzxRt1www1q06aN25TR+++/X6+//rrmzp2r1q1bq2vXrpo3b54rVgCVz2ada+QXAACAB6hUAAAAI0gqAACAESQVAADACJIKAABgBEkFAAAwgqQCAAAYQVIBAACMIKkAAABGkFQAAAAjSCoAAIARJBUAAMAIkgoAAGDE/wfNwTpKrgf8yQAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# confusion matrix for male group\n",
+        "confusion_matrix = metrics.confusion_matrix(df_male_Y, malePredList)\n",
+        "\n",
+        "cm_display = metrics.ConfusionMatrixDisplay(confusion_matrix = confusion_matrix, display_labels = [False, True])\n",
+        "\n",
+        "cm_display.plot()\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 449
+        },
+        "id": "rk8K_P3pNfUx",
+        "outputId": "da083975-26a4-4556-fd30-681a536ee69b"
+      },
+      "execution_count": 85,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 2 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhUAAAGwCAYAAAAe3Ze+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA3TUlEQVR4nO3deXQUZfr//U9n64RsLAOJgYBBQEAWEXwwIgKKAg4KysijxjEo6CggEmRzxrBEIIrjFgaDgw4YhRHUEQWEGURFIsgXUFQQoiwKComOGEISsnXX7w+knRbQJHVnafv9OqfOoavuqr7KE+HKdd11l8OyLEsAAAA2BdR1AAAA4LeBpAIAABhBUgEAAIwgqQAAAEaQVAAAACNIKgAAgBEkFQAAwIigug7AF7jdbh0+fFiRkZFyOBx1HQ4AoIosy9Lx48cVFxengICa+326pKREZWVltq8TEhKi0NBQAxHVLpKKSjh8+LDi4+PrOgwAgE2HDh1SixYtauTaJSUlSmgVodxvXbavFRsbqwMHDvhcYkFSUQmRkZGSpGtX3Kzg8JA6jgaoGfueb1fXIQA1xlVWop3LH/L8fV4TysrKlPutS19tP1dRkdWvhhQcd6tV9y9VVlZGUvFbdKrlERweQlKB36zAEN/6ywuojtpoYUdEOhQRWf3vcct32+wkFQAAGOSy3HLZeKuWy3KbC6aWkVQAAGCQW5bcqn5WYefcusYjpQAAwAgqFQAAGOSWW3YaGPbOrlskFQAAGOSyLLms6rcw7Jxb12h/AAAAI6hUAABgkD9P1CSpAADAILcsufw0qaD9AQAAjKBSAQCAQbQ/AACAETz9AQAAYBOVCgAADHL/uNk531eRVAAAYJDL5tMfds6tayQVAAAY5LJk8y2l5mKpbcypAAAARlCpAADAIH+eU0GlAgAAg9xyyGVjc8tRpe977733dO211youLk4Oh0MrVqzwOm5ZlqZNm6ZzzjlHYWFh6t+/v7744guvMUePHlVSUpKioqLUsGFDjRw5UoWFhVW+d5IKAAB8WFFRkbp27ar58+ef8fjcuXOVkZGhBQsWaMuWLQoPD9eAAQNUUlLiGZOUlKRdu3Zp3bp1WrVqld577z3dddddVY6F9gcAAAa5rZObnfMlqaCgwGu/0+mU0+k8bfygQYM0aNCgM17Lsiw9+eSTevDBBzVkyBBJUlZWlmJiYrRixQrddNNN2r17t9auXautW7eqR48ekqR58+bpmmuu0V//+lfFxcVVOnYqFQAAGGSn9XFqk6T4+HhFR0d7tvT09CrHcuDAAeXm5qp///6efdHR0erZs6c2b94sSdq8ebMaNmzoSSgkqX///goICNCWLVuq9H1UKgAAqIcOHTqkqKgoz+czVSl+TW5uriQpJibGa39MTIznWG5urpo1a+Z1PCgoSI0bN/aMqSySCgAADPrfakN1z5ekqKgor6TCF9D+AADAILflsL2ZEhsbK0nKy8vz2p+Xl+c5Fhsbq2+//dbreEVFhY4ePeoZU1kkFQAA/EYlJCQoNjZW69ev9+wrKCjQli1blJiYKElKTExUfn6+tm/f7hnz9ttvy+12q2fPnlX6PtofAAAYZKr9UVmFhYXau3ev5/OBAwe0Y8cONW7cWC1bttT48eM1a9YstW3bVgkJCUpNTVVcXJyGDh0qSerQoYMGDhyoO++8UwsWLFB5ebnGjh2rm266qUpPfkgkFQAAGOVSgFw2GgGuKo7ftm2b+vXr5/k8YcIESVJycrIWL16syZMnq6ioSHfddZfy8/N12WWXae3atQoNDfWcs2TJEo0dO1ZXXnmlAgICNGzYMGVkZFQ5dpIKAAAMsmzOi7CqeG7fvn1lWWdfGMPhcCgtLU1paWlnHdO4cWMtXbq0St97JsypAAAARlCpAADAoNqeU1GfkFQAAGCQywqQy7Ixp8LGEt91jfYHAAAwgkoFAAAGueWQ28bv7G75bqmCpAIAAIP8eU4F7Q8AAGAElQoAAAyyP1GT9gcAANCpORXVb2HYObeu0f4AAABGUKkAAMAgt813f/D0BwAAkMScCgAAYIhbAX67TgVzKgAAgBFUKgAAMMhlOeSy8epzO+fWNZIKAAAMctmcqOmi/QEAAPwdlQoAAAxyWwFy23j6w83THwAAQKL9AQAAYBuVCgAADHLL3hMcbnOh1DqSCgAADLK/+JXvNhF8N3IAAFCvUKkAAMAg++/+8N3f90kqAAAwyC2H3LIzp4IVNQEAgPy7UuG7kQMAgHqFSgUAAAbZX/zKd3/fJ6kAAMAgt+WQ2846FT78llLfTYcAAEC9QqUCAACD3DbbH768+BVJBQAABtl/S6nvJhW+GzkAAKhXqFQAAGCQSw65bCxgZefcukZSAQCAQbQ/AAAAbKJSAQCAQS7Za2G4zIVS60gqAAAwyJ/bHyQVAAAYxAvFAAAAbKJSAQCAQZYcctuYU2HxSCkAAJBofwAAANhGpQIAAIP8+dXnJBUAABjksvmWUjvn1jXfjRwAANQrVCoAADCI9gcAADDCrQC5bTQC7Jxb13w3cgAAUK9QqQAAwCCX5ZDLRgvDzrl1jaQCAACDmFMBAACMsGy+pdRiRU0AAODvqFQAAGCQSw65bLwUzM65dY2kAgAAg9yWvXkRbstgMLWM9gcAADCCSgXqjOWydOK5EpX+p0zu790K+F2AnNeEKGxEqByOk1l+6btlKl1Rqoocl6wCS9GLIhXUjh9b+J7kyz/S2AFb9M/3O+vxN3tJkkKCKjR+0GZd1WWvQgJd+uCLeD3yRm8dLWpQx9HCDrfNiZp2zq1rPhn54sWL1bBhw7oOAzadeLFEJStKFT6hgRoujVKD0WE6saREJa+U/jSoxFJQlyA1uCes7gIFbOrY/Ftdf/Fn+vxIE6/9KddsUu/2X+mBf16tPz07RL+LKtbcpH/XUZQwxS2H7c1X1WlSMWLECDkcjtO2vXv31mVYqCUVO10K6R2skEuDFXhOoJz9QhTy/wWr4jOXZ4xzoFMN7ghT8MVUJ+CbwkLKlTZ8veas6KPjJ0I8+8OdpRrSfY+eeDNR2/Y3157DTZX2al91bZWnTvF5dRgxUH11XqkYOHCgjhw54rUlJCTUdVioBUGdAlW+rUKugyeTiIovKlT+SYVCLiGBwG/H5Gs36v2clvq/fS289ndo/l8FB7m99n/130Y68kOEOsfn1naYMOjUipp2Nl9V50mF0+lUbGys1/bUU0+pc+fOCg8PV3x8vEaPHq3CwsKzXuPjjz9Wv379FBkZqaioKHXv3l3btm3zHM/Ozlbv3r0VFham+Ph4jRs3TkVFRbVxe/gFYX8MVUj/YOXfUqDvL/9Bx24/rrDhTjkHOOs6NMCIqzrvVfu4/2r+f3qedqxJRLHKKgJUWOL98360KExNIk/UVoioAafmVNjZfFW9jDwgIEAZGRnatWuXnn/+eb399tuaPHnyWccnJSWpRYsW2rp1q7Zv366pU6cqODhYkrRv3z4NHDhQw4YN0yeffKJly5YpOztbY8eOPev1SktLVVBQ4LXBvLK3y1X2nzJFzAhX9KIoRTzYQCf+WaqSN0t//WSgnouJLtT9g99X6vIrVVZB9Q3+oc5/0letWqWIiAjP50GDBunll1/2fD733HM1a9Ys3X333Xr66afPeI2DBw9q0qRJat++vSSpbdu2nmPp6elKSkrS+PHjPccyMjLUp08fZWZmKjQ09LTrpaena+bMmSZuD7+geH6xwm4NlbP/yT5z0HmBcuW6deKFEoVeQ7UCvq193HdqEnFCL4x5xbMvKNBSt3OP6MZLdmrc4t8rJMitiNBSr2pF4/AT+v44E5N9mVs23/3hwxM16zyp6NevnzIzMz2fw8PD9dZbbyk9PV179uxRQUGBKioqVFJSouLiYjVocPqjVhMmTNCoUaP0wgsvqH///rrxxht13nnnSTrZGvnkk0+0ZMkSz3jLsuR2u3XgwAF16NDhtOs98MADmjBhgudzQUGB4uPjTd42JFklkgK8/+dxBEjy4YVfgFO27muum54a7rVv2rB39OV3DZX1XjflHgtXeUWALj7vG72zq7UkqdXv8nVOo0J9eii2LkKGIZbNJzgskorqCw8PV5s2bTyfv/zySw0ePFj33HOPZs+ercaNGys7O1sjR45UWVnZGZOKGTNm6JZbbtHq1au1Zs0aTZ8+XS+99JKuv/56FRYW6k9/+pPGjRt32nktW7Y8Y0xOp1NOJ78p17SQXsE68fwJBcQEKDAhQBWfu3RiWamcv/9phry7wC13rlvu/57MNFwH3ZIqFNAkQAFN6mX3DpAkFZeFaN+3jb32nSgL0rHiUM/+17e3V8qgTSoodqqoNESTBmfrk69itPNQTF2EDEN4S2k9sn37drndbj322GMKCDj5j8by5ct/9bx27dqpXbt2SklJ0c0336xFixbp+uuv10UXXaTPPvvMK3FB/RCe0kDFC0+o6K/Fcv9wcvGr0CFOhd3+U0uqbGO5iuYUez4XTj85wTbsjlA1GEmJGL7tiTcvlWU59Mgt/1FI0E+LXwG+qt4lFW3atFF5ebnmzZuna6+9Vu+//74WLFhw1vEnTpzQpEmT9Ic//EEJCQn6+uuvtXXrVg0bNkySNGXKFF1yySUaO3asRo0apfDwcH322Wdat26d/va3v9XWbeEMHOEOhY9voPDxZx8T+nunQn9P1Qi/DXc/N8Trc1lFkOau7K25K0kkfktqe0VNl8ulGTNm6MUXX1Rubq7i4uI0YsQIPfjgg57ViS3L0vTp07Vw4ULl5+erV69eyszM9JqDaEK9qx937dpVjz/+uB555BF16tRJS5YsUXp6+lnHBwYG6vvvv9dtt92mdu3aafjw4Ro0aJBnomWXLl20YcMGff755+rdu7e6deumadOmKS4urrZuCQDgR061P+xsVfHII48oMzNTf/vb37R792498sgjmjt3rubNm+cZM3fuXGVkZGjBggXasmWLwsPDNWDAAJWUlBi9d4dlWUyL+xUFBQWKjo7WDeuSFRwe8usnAD7oi2fb13UIQI1xlZXo4xf/omPHjikqKqpGvuPUvxVD/nOHrX8ryovK9PrV/9ChQ4e8Yj3bfL/BgwcrJiZGzz33nGffsGHDFBYWphdffFGWZSkuLk7333+/Jk6cKEk6duyYYmJitHjxYt10003VjvXn6l2lAgAAX2bq3R/x8fGKjo72bGer2l966aVav369Pv/8c0knn3rMzs7WoEGDJEkHDhxQbm6u+vfv7zknOjpaPXv21ObNm43ee72bUwEAgC8z9fTHmSoVZzJ16lQVFBSoffv2CgwMlMvl0uzZs5WUlCRJys09uex7TIz3U0UxMTGeY6aQVAAAUA9FRUVVqlWzfPlyLVmyREuXLtUFF1ygHTt2aPz48YqLi1NycnItRPoTkgoAAAyq7XUqJk2apKlTp3rmRnTu3FlfffWV0tPTlZycrNjYk4up5eXl6ZxzzvGcl5eXpwsvvLDacZ4JcyoAADCotp/+KC4u9qzrdEpgYKDcbrckKSEhQbGxsVq/fr3neEFBgbZs2aLExET7N/w/qFQAAODDrr32Ws2ePVstW7bUBRdcoI8++kiPP/647rjjDkmSw+HQ+PHjNWvWLLVt21YJCQlKTU1VXFychg4dajQWkgoAAAyq7fbHvHnzlJqaqtGjR+vbb79VXFyc/vSnP2natGmeMZMnT1ZRUZHuuusu5efn67LLLtPatWvP+FJNO0gqAAAwyJK9N41WdfGoyMhIPfnkk3ryySfPOsbhcCgtLU1paWnVjqsySCoAADDIn18oxkRNAABgBJUKAAAM8udKBUkFAAAG+XNSQfsDAAAYQaUCAACD/LlSQVIBAIBBluWQZSMxsHNuXaP9AQAAjKBSAQCAQW45bC1+ZefcukZSAQCAQf48p4L2BwAAMIJKBQAABvnzRE2SCgAADPLn9gdJBQAABvlzpYI5FQAAwAgqFQAAGGTZbH/4cqWCpAIAAIMsSZZl73xfRfsDAAAYQaUCAACD3HLIwYqaAADALp7+AAAAsIlKBQAABrkthxwsfgUAAOyyLJtPf/jw4x+0PwAAgBFUKgAAMMifJ2qSVAAAYBBJBQAAMMKfJ2oypwIAABhBpQIAAIP8+ekPkgoAAAw6mVTYmVNhMJhaRvsDAAAYQaUCAACDePoDAAAYYf242TnfV9H+AAAARlCpAADAINofAADADD/uf5BUAABgks1KhXy4UsGcCgAAYASVCgAADGJFTQAAYIQ/T9Sk/QEAAIygUgEAgEmWw95kSx+uVJBUAABgkD/PqaD9AQAAjKBSAQCASSx+BQAATPDnpz8qlVS88cYblb7gddddV+1gAACA76pUUjF06NBKXczhcMjlctmJBwAA3+fDLQw7KpVUuN3umo4DAIDfBH9uf9h6+qOkpMRUHAAA/DZYBjYfVeWkwuVy6aGHHlLz5s0VERGh/fv3S5JSU1P13HPPGQ8QAAD4hionFbNnz9bixYs1d+5chYSEePZ36tRJzz77rNHgAADwPQ4Dm2+qclKRlZWlv//970pKSlJgYKBnf9euXbVnzx6jwQEA4HNof1TeN998ozZt2py23+12q7y83EhQAADA91Q5qejYsaM2btx42v5XXnlF3bp1MxIUAAA+y48rFVVeUXPatGlKTk7WN998I7fbrX/961/KyclRVlaWVq1aVRMxAgDgO/z4LaVVrlQMGTJEK1eu1FtvvaXw8HBNmzZNu3fv1sqVK3XVVVfVRIwAAMAHVOvdH71799a6detMxwIAgM/z51efV/uFYtu2bdPu3bslnZxn0b17d2NBAQDgs3hLaeV9/fXXuvnmm/X++++rYcOGkqT8/Hxdeumleumll9SiRQvTMQIAAB9Q5TkVo0aNUnl5uXbv3q2jR4/q6NGj2r17t9xut0aNGlUTMQIA4DtOTdS0s/moKlcqNmzYoE2bNun888/37Dv//PM1b9489e7d22hwAAD4God1crNzvq+qclIRHx9/xkWuXC6X4uLijAQFAIDP8uM5FVVufzz66KO69957tW3bNs++bdu26b777tNf//pXo8EBAADfUalKRaNGjeRw/NTjKSoqUs+ePRUUdPL0iooKBQUF6Y477tDQoUNrJFAAAHyCHy9+Vamk4sknn6zhMAAA+I3w4/ZHpZKK5OTkmo4DAABU0zfffKMpU6ZozZo1Ki4uVps2bbRo0SL16NFDkmRZlqZPn66FCxcqPz9fvXr1UmZmptq2bWs0jirPqfhfJSUlKigo8NoAAPBrtfxCsR9++EG9evVScHCw1qxZo88++0yPPfaYGjVq5Bkzd+5cZWRkaMGCBdqyZYvCw8M1YMAAlZSU2LxZb1V++qOoqEhTpkzR8uXL9f3335923OVyGQkMAACfZKj98fNf1J1Op5xO52nDH3nkEcXHx2vRokWefQkJCT9dzrL05JNP6sEHH9SQIUMkSVlZWYqJidGKFSt000032QjWW5UrFZMnT9bbb7+tzMxMOZ1OPfvss5o5c6bi4uKUlZVlLDAAAPxZfHy8oqOjPVt6evoZx73xxhvq0aOHbrzxRjVr1kzdunXTwoULPccPHDig3Nxc9e/f37MvOjpaPXv21ObNm43GXOVKxcqVK5WVlaW+ffvq9ttvV+/evdWmTRu1atVKS5YsUVJSktEAAQDwKYae/jh06JCioqI8u89UpZCk/fv3KzMzUxMmTNCf//xnbd26VePGjVNISIiSk5OVm5srSYqJifE6LyYmxnPMlConFUePHlXr1q0lSVFRUTp69Kgk6bLLLtM999xjNDgAAHyNqRU1o6KivJKKs3G73erRo4fmzJkjSerWrZt27typBQsW1PqDFlVuf7Ru3VoHDhyQJLVv317Lly+XdLKCceoFYwAAoHacc8456tixo9e+Dh066ODBg5Kk2NhYSVJeXp7XmLy8PM8xU6qcVNx+++36+OOPJUlTp07V/PnzFRoaqpSUFE2aNMlocAAA+JxafvqjV69eysnJ8dr3+eefq1WrVpJOTtqMjY3V+vXrPccLCgq0ZcsWJSYmVvn2fkmV2x8pKSmeP/fv31979uzR9u3b1aZNG3Xp0sVocAAA4JelpKTo0ksv1Zw5czR8+HD93//9n/7+97/r73//uyTJ4XBo/PjxmjVrltq2bauEhASlpqYqLi7O+CrYVU4qfq5Vq1aebAgAAH/nkM05FVUcf/HFF+u1117TAw88oLS0NCUkJOjJJ5/0enBi8uTJKioq0l133aX8/HxddtllWrt2rUJDQ6sf6BlUKqnIyMio9AXHjRtX7WAAAEDVDR48WIMHDz7rcYfDobS0NKWlpdVoHJVKKp544olKXczhcPymk4qjV+UryBFc12EANWLr4cy6DgGoMQXH3Wr0Yi19GS8U+2WnnvYAAAC/wo9fKGbr3R8AAACn2J6oCQAA/ocfVypIKgAAMMjUipq+iPYHAAAwgkoFAAAm+XH7o1qVio0bN+rWW29VYmKivvnmG0nSCy+8oOzsbKPBAQDgc2p5me76pMpJxauvvqoBAwYoLCxMH330kUpLSyVJx44d87whDQAA+J8qJxWzZs3SggULtHDhQgUH/7QQVK9evfThhx8aDQ4AAF9zaqKmnc1XVXlORU5Oji6//PLT9kdHRys/P99ETAAA+C4/XlGzypWK2NhY7d2797T92dnZat26tZGgAADwWcypqLw777xT9913n7Zs2SKHw6HDhw9ryZIlmjhxou65556aiBEAAPiAKrc/pk6dKrfbrSuvvFLFxcW6/PLL5XQ6NXHiRN177701ESMAAD7Dnxe/qnJS4XA49Je//EWTJk3S3r17VVhYqI4dOyoiIqIm4gMAwLf48ToV1V78KiQkRB07djQZCwAA8GFVTir69esnh+PsM1PffvttWwEBAODT7D4W6k+VigsvvNDrc3l5uXbs2KGdO3cqOTnZVFwAAPgm2h+V98QTT5xx/4wZM1RYWGg7IAAA4JuMvaX01ltv1T/+8Q9TlwMAwDf58ToVxt5SunnzZoWGhpq6HAAAPolHSqvghhtu8PpsWZaOHDmibdu2KTU11VhgAADAt1Q5qYiOjvb6HBAQoPPPP19paWm6+uqrjQUGAAB8S5WSCpfLpdtvv12dO3dWo0aNaiomAAB8lx8//VGliZqBgYG6+uqreRspAABn4c+vPq/y0x+dOnXS/v37ayIWAADgw6qcVMyaNUsTJ07UqlWrdOTIERUUFHhtAAD4PT98nFSqwpyKtLQ03X///brmmmskSdddd53Xct2WZcnhcMjlcpmPEgAAX+HHcyoqnVTMnDlTd999t955552ajAcAAPioSicVlnUyderTp0+NBQMAgK9j8atK+qW3kwIAANH+qKx27dr9amJx9OhRWwEBAADfVKWkYubMmaetqAkAAH5C+6OSbrrpJjVr1qymYgEAwPf5cfuj0utUMJ8CAAD8kio//QEAAH6BH1cqKp1UuN3umowDAIDfBOZUAAAAM/y4UlHld38AAACcCZUKAABM8uNKBUkFAAAG+fOcCtofAADACCoVAACYRPsDAACYQPsDAADAJioVAACYRPsDAAAY4cdJBe0PAABgBJUKAAAMcvy42TnfV5FUAABgkh+3P0gqAAAwiEdKAQAAbKJSAQCASbQ/AACAMT6cGNhB+wMAABhBpQIAAIP8eaImSQUAACb58ZwK2h8AAMAIKhUAABhE+wMAAJhB+wMAAMAeKhUAABhE+wMAAJjhx+0PkgoAAEzy46SCORUAAMAIKhUAABjkz3MqqFQAAGCSZWCrpocfflgOh0Pjx4/37CspKdGYMWPUpEkTRUREaNiwYcrLy6v+l/wCkgoAAH4Dtm7dqmeeeUZdunTx2p+SkqKVK1fq5Zdf1oYNG3T48GHdcMMNNRIDSQUAAAY5LMv2JkkFBQVeW2lp6Vm/s7CwUElJSVq4cKEaNWrk2X/s2DE999xzevzxx3XFFVeoe/fuWrRokTZt2qQPPvjA+L2TVAAAYJKh9kd8fLyio6M9W3p6+lm/csyYMfr973+v/v37e+3fvn27ysvLvfa3b99eLVu21ObNm43c7v9ioiYAAPXQoUOHFBUV5fnsdDrPOO6ll17Shx9+qK1bt552LDc3VyEhIWrYsKHX/piYGOXm5hqNVyKpAADAKFNPf0RFRXklFWdy6NAh3XfffVq3bp1CQ0Or/6WG0P4AAMCkWnz6Y/v27fr222910UUXKSgoSEFBQdqwYYMyMjIUFBSkmJgYlZWVKT8/3+u8vLw8xcbG2rvPM6BSAQCAj7ryyiv16aefeu27/fbb1b59e02ZMkXx8fEKDg7W+vXrNWzYMElSTk6ODh48qMTEROPxkFQAAGBQbS5+FRkZqU6dOnntCw8PV5MmTTz7R44cqQkTJqhx48aKiorSvffeq8TERF1yySXVD/IsSCoAADCpnr3744knnlBAQICGDRum0tJSDRgwQE8//bTZL/kRSQUAAAbV9TLd7777rtfn0NBQzZ8/X/Pnz7d34UpgoiYAADCCSgUAACbVs/ZHbSKpAADAMF9+06gdtD8AAIARVCoAADDJsk5uds73USQVAAAYVNdPf9Ql2h8AAMAIKhUAAJjE0x8AAMAEh/vkZud8X0X7AwAAGEGlAnWmU89C3Tj6O7XtXKwmsRWacce52rw2+n9GWLptUp4G3vK9IqJc+mxbuDKmttDhA846ixn4JZ9+EK6Xn26mLz5toKN5wZr+3AFdOuiY57hlSVmPxmrt0iYqLAhUxx5FGvfwITVvXeZ1nS1vRWnJEzE6sDtMIU63Ol9SpBmLDtT27aC6/Lj9QaUCdSa0gVv7d4Xqb39uccbjw8d8pyF3fKd5U1vovsFtVVIcoDlL9yvY6cO1QfymlRQHqPUFJzR2ztdnPL58fjO9/o+muvfhQ3pq1ecKbeDWn285T2UlDs+YjaujNXdcS139/x9V5rocPf76F+p3/Q+1dQsw4NTTH3Y2X1WvkgqHw/GL24wZM+o6RBi07Z0oPT/3HG3yqk6cYmnoqO/0z6ditPnf0TqwO0xzx7VUk5hyXTrw2BnGA3Xv4iuOa8SUXPUadPrPqGVJK55tqpvvy9WlAwvUumOJJmd8pe/zgj3/D7gqpAXTmuvOBw9r8G3fq8V5pWrVrlR9rsuv5TuBLafWqbCz+ah61f44cuSI58/Lli3TtGnTlJOT49kXERHh+bNlWXK5XAoKqle3AENiW5apSUyFPtwY6dlXfDxQez5qoA7di7Xh9UZ1GB1QdbkHQ3T022Bd1LvQsy88yq323Yq1e3u4+g7N1xefNtB/j4TIESCNvqqdfvguWK0vOKE7Uw/r3PYldRg9UDn1qlIRGxvr2aKjo+VwODyf9+zZo8jISK1Zs0bdu3eX0+lUdna2RowYoaFDh3pdZ/z48erbt6/ns9vtVnp6uhISEhQWFqauXbvqlVdeOWscpaWlKigo8NpQuxo3q5Ak5X/nnTTmfxekxs3K6yIkwJaj3578WW7Y1Pvnt2HTcs+x3K9CJEkvPharm8fnKS1rvyKiXZo0rI0Kfgis3YBRbbQ/fMjUqVP18MMPa/fu3erSpUulzklPT1dWVpYWLFigXbt2KSUlRbfeeqs2bNhw1vHR0dGeLT4+3uQtAMAZuX+cLnTzfXnq/ftjatvlhO5/4qAcDmnjqoZ1GhuqwDKw+Sif6x2kpaXpqquuqvT40tJSzZkzR2+99ZYSExMlSa1bt1Z2draeeeYZ9enT57RzHnjgAU2YMMHzuaCggMSilv30W12Fjn4b7NnfsGmF9u0Kq6uwgGr7qfoWrCYxFZ79+d8F67wLTpwc8+P+lm1/anWEOC3FtirVt98EC6jvfC6p6NGjR5XG7927V8XFxaclImVlZerWrdsZz3E6nXI6eWyxLuUeDNH3eUHqdtlx7f8xiWgQ4VL7bsValdWkjqMDqi62ZZkaNyvXR9kROq/TySSi6HiA9nzUQINv+68kqW2XYgU73fp6n1OdehZJkirKpbxDIYppQdvPV/jzuz98LqkIDw/3+hwQECDrZzNly8t/+p+vsPDkpKjVq1erefPmXuNIHOpWaAOX4hJ+ej4/Nr5MrS84oeP5gfrum5AfZ8p/q28OOJV7METJk3O9ZsoD9c2JogCvdVRyD4Vo384wRTasULMW5Z4nmponlCq2ZZmen3uO1xNN4ZFu/f6P3+uFx2LVNK5czVqU6ZXMZpKk3oPz6+KWUB28pdR3NW3aVDt37vTat2PHDgUHnywVduzYUU6nUwcPHjxjqwN1p13XE3r01X2ez3fPPCxJ+s+yRnospaWWz2+q0AZu3Tf3a0VEubRra7j+ktRa5aU+NxUIfuLzjxto8h/aeD4/M+PkLzJXDT+qiU8e1PAx36qkOEBPTY5XYUGgLri4SLOX7FdI6E//iNyZ+o0CAy3NHddSZSUBOr9bsR55eZ8iG7pq/X6AqvL5pOKKK67Qo48+qqysLCUmJurFF1/Uzp07Pa2NyMhITZw4USkpKXK73brssst07Ngxvf/++4qKilJycnId34H/+mRzhAbEdf2FEQ5lPRqrrEdjay0mwI6ulxbq34d3nPW4wyElT85V8uTcs44JCpbumn5Yd00/XAMRojbQ/vBhAwYMUGpqqiZPnqySkhLdcccduu222/Tpp596xjz00ENq2rSp0tPTtX//fjVs2FAXXXSR/vznP9dh5ACA3yQ/XqbbYf18QgJOU1BQoOjoaPXVEAU5mIGN36Zf+g0b8HUFx91q1G6/jh07pqioqJr5jh//rUgcmKag4NBqX6eivESb106r0Vhris9XKgAAqE9ofwAAADPc1snNzvk+iqQCAACT/HhOBc/mAQAAI6hUAABgkEM251QYi6T2kVQAAGCSH6+oSfsDAAAYQaUCAACDeKQUAACYwdMfAAAA9lCpAADAIIdlyWFjsqWdc+saSQUAACa5f9zsnO+jaH8AAAAjqFQAAGAQ7Q8AAGCGHz/9QVIBAIBJrKgJAABgD5UKAAAMYkVNAABgBu0PAAAAe6hUAABgkMN9crNzvq8iqQAAwCTaHwAAAPZQqQAAwCQWvwIAACb48zLdtD8AAIARVCoAADDJjydqklQAAGCSJcnOY6G+m1OQVAAAYBJzKgAAAGyiUgEAgEmWbM6pMBZJrSOpAADAJD+eqEn7AwAAGEGlAgAAk9ySHDbP91EkFQAAGMTTHwAAADZRqQAAwCQ/nqhJUgEAgEl+nFTQ/gAAAEZQqQAAwCQ/rlSQVAAAYBKPlAIAABN4pBQAAMAmkgoAAEw6NafCzlYF6enpuvjiixUZGalmzZpp6NChysnJ8RpTUlKiMWPGqEmTJoqIiNCwYcOUl5dn8q4lkVQAAGCW27K/VcGGDRs0ZswYffDBB1q3bp3Ky8t19dVXq6ioyDMmJSVFK1eu1Msvv6wNGzbo8OHDuuGGG0zfOXMqAACojwoKCrw+O51OOZ3O08atXbvW6/PixYvVrFkzbd++XZdffrmOHTum5557TkuXLtUVV1whSVq0aJE6dOigDz74QJdccomxmKlUAABgkqH2R3x8vKKjoz1benp6pb7+2LFjkqTGjRtLkrZv367y8nL179/fM6Z9+/Zq2bKlNm/ebPTWqVQAAGCUzXUqdPLcQ4cOKSoqyrP3TFWKn3O73Ro/frx69eqlTp06SZJyc3MVEhKihg0beo2NiYlRbm6ujThPR1IBAEA9FBUV5ZVUVMaYMWO0c+dOZWdn11BUv4z2BwAAJtXy0x+njB07VqtWrdI777yjFi1aePbHxsaqrKxM+fn5XuPz8vIUGxtr505PQ1IBAIBJtfz0h2VZGjt2rF577TW9/fbbSkhI8DrevXt3BQcHa/369Z59OTk5OnjwoBITE43c8im0PwAA8GFjxozR0qVL9frrrysyMtIzTyI6OlphYWGKjo7WyJEjNWHCBDVu3FhRUVG69957lZiYaPTJD4mkAgAAsyz3yc3O+VWQmZkpSerbt6/X/kWLFmnEiBGSpCeeeEIBAQEaNmyYSktLNWDAAD399NPVj/EsSCoAADCplt9SalVifGhoqObPn6/58+dXN6pKIakAAMAkt6VTj4VW/3zfxERNAABgBJUKAABMquX2R31CUgEAgEmWbCYVxiKpdbQ/AACAEVQqAAAwifYHAAAwwu2WZGOdCreNc+sY7Q8AAGAElQoAAEyi/QEAAIzw46SC9gcAADCCSgUAACb58TLdJBUAABhkWW5ZNt5SaufcukZSAQCASZZlr9rAnAoAAODvqFQAAGCSZXNOhQ9XKkgqAAAwye2WHDbmRfjwnAraHwAAwAgqFQAAmET7AwAAmGC53bJstD98+ZFS2h8AAMAIKhUAAJhE+wMAABjhtiSHfyYVtD8AAIARVCoAADDJsiTZWafCdysVJBUAABhkuS1ZNtofFkkFAACQ9OOKmKyoCQAAUG1UKgAAMIj2BwAAMMOP2x8kFZVwKmusULmt9UyA+qzguO/+RQb8moLCkz/ftVEFsPtvRYXKzQVTy0gqKuH48eOSpGy9WceRADWnUbu6jgCoecePH1d0dHSNXDskJESxsbHKzrX/b0VsbKxCQkIMRFW7HJYvN29qidvt1uHDhxUZGSmHw1HX4fiFgoICxcfH69ChQ4qKiqrrcACj+PmufZZl6fjx44qLi1NAQM09o1BSUqKysjLb1wkJCVFoaKiBiGoXlYpKCAgIUIsWLeo6DL8UFRXFX7r4zeLnu3bVVIXif4WGhvpkMmAKj5QCAAAjSCoAAIARJBWol5xOp6ZPny6n01nXoQDG8fON3yomagIAACOoVAAAACNIKgAAgBEkFQAAwAiSCtQrixcvVsOGDes6DABANZBUoEaMGDFCDofjtG3v3r11HRpg1Jl+zv93mzFjRl2HCNQaVtREjRk4cKAWLVrkta9p06Z1FA1QM44cOeL587JlyzRt2jTl5OR49kVERHj+bFmWXC6XgoL4qxe/TVQqUGOcTqdiY2O9tqeeekqdO3dWeHi44uPjNXr0aBUWFp71Gh9//LH69eunyMhIRUVFqXv37tq2bZvneHZ2tnr37q2wsDDFx8dr3LhxKioqqo3bAyTJ6+c7OjpaDofD83nPnj2KjIzUmjVr1L17dzmdTmVnZ2vEiBEaOnSo13XGjx+vvn37ej673W6lp6crISFBYWFh6tq1q1555ZXavTmgikgqUKsCAgKUkZGhXbt26fnnn9fbb7+tyZMnn3V8UlKSWrRooa1bt2r79u2aOnWqgoODJUn79u3TwIEDNWzYMH3yySdatmyZsrOzNXbs2Nq6HaBSpk6dqocffli7d+9Wly5dKnVOenq6srKytGDBAu3atUspKSm69dZbtWHDhhqOFqg+anCoMatWrfIq/Q4aNEgvv/yy5/O5556rWbNm6e6779bTTz99xmscPHhQkyZNUvv27SVJbdu29RxLT09XUlKSxo8f7zmWkZGhPn36KDMz069f6oP6JS0tTVdddVWlx5eWlmrOnDl66623lJiYKElq3bq1srOz9cwzz6hPnz41FSpgC0kFaky/fv2UmZnp+RweHq633npL6enp2rNnjwoKClRRUaGSkhIVFxerQYMGp11jwoQJGjVqlF544QX1799fN954o8477zxJJ1sjn3zyiZYsWeIZb1mW3G63Dhw4oA4dOtT8TQKV0KNHjyqN37t3r4qLi09LRMrKytStWzeToQFGkVSgxoSHh6tNmzaez19++aUGDx6se+65R7Nnz1bjxo2VnZ2tkSNHqqys7IxJxYwZM3TLLbdo9erVWrNmjaZPn66XXnpJ119/vQoLC/WnP/1J48aNO+28li1b1ui9AVURHh7u9TkgIEA/f0NCeXm558+n5hmtXr1azZs39xrH+0JQn5FUoNZs375dbrdbjz32mAICTk7nWb58+a+e165dO7Vr104pKSm6+eabtWjRIl1//fW66KKL9Nlnn3klLoAvaNq0qXbu3Om1b8eOHZ75Qh07dpTT6dTBgwdpdcCnMFETtaZNmzYqLy/XvHnztH//fr3wwgtasGDBWcefOHFCY8eO1bvvvquvvvpK77//vrZu3eppa0yZMkWbNm3S2LFjtWPHDn3xxRd6/fXXmaiJeu+KK67Qtm3blJWVpS+++ELTp0/3SjIiIyM1ceJEpaSk6Pnnn9e+ffv04Ycfat68eXr++efrMHLgl5FUoNZ07dpVjz/+uB555BF16tRJS5YsUXp6+lnHBwYG6vvvv9dtt92mdu3aafjw4Ro0aJBmzpwpSerSpYs2bNigzz//XL1791a3bt00bdo0xcXF1dYtAdUyYMAApaamavLkybr44ot1/Phx3XbbbV5jHnroIaWmpio9PV0dOnTQwIEDtXr1aiUkJNRR1MCv49XnAADACCoVAADACJIKAABgBEkFAAAwgqQCAAAYQVIBAACMIKkAAABGkFQAAAAjSCoAAIARJBWAjxgxYoSGDh3q+dy3b1/Pa99r07vvviuHw6H8/PyzjnE4HFqxYkWlrzljxgxdeOGFtuL68ssv5XA4tGPHDlvXAVB9JBWADSNGjJDD4ZDD4VBISIjatGmjtLQ0VVRU1Ph3/+tf/9JDDz1UqbGVSQQAwC7eUgrYNHDgQC1atEilpaV68803NWbMGAUHB+uBBx44bWxZWZlCQkKMfG/jxo2NXAcATKFSAdjkdDoVGxurVq1a6Z577lH//v31xhtvSPqpZTF79mzFxcXp/PPPlyQdOnRIw4cPV8OGDdW4cWMNGTJEX375peeaLpdLEyZMUMOGDdWkSRNNnjxZP39Nz8/bH6WlpZoyZYri4+PldDrVpk0bPffcc/ryyy/Vr18/SVKjRo3kcDg0YsQISZLb7VZ6eroSEhIUFhamrl276pVXXvH6njfffFPt2rVTWFiY+vXr5xVnZU2ZMkXt2rVTgwYN1Lp1a6Wmpqq8vPy0cc8884zi4+PVoEEDDR8+XMeOHfM6/uyzz6pDhw4KDQ1V+/bt9fTTT1c5FgA1h6QCMCwsLExlZWWez+vXr1dOTo7WrVunVatWqby8XAMGDFBkZKQ2btyo999/XxERERo4cKDnvMcee0yLFy/WP/7xD2VnZ+vo0aN67bXXfvF7b7vtNv3zn/9URkaGdu/erWeeeUYRERGKj4/Xq6++KknKycnRkSNH9NRTT0mS0tPTlZWVpQULFmjXrl1KSUnRrbfeqg0bNkg6mfzccMMNuvbaa7Vjxw6NGjVKU6dOrfJ/k8jISC1evFifffaZnnrqKS1cuFBPPPGE15i9e/dq+fLlWrlypdauXauPPvpIo0eP9hxfsmSJpk2bptmzZ2v37t2aM2eOUlNTeRU4UJ9YAKotOTnZGjJkiGVZluV2u61169ZZTqfTmjhxoud4TEyMVVpa6jnnhRdesM4//3zL7XZ79pWWllphYWHWv//9b8uyLOucc86x5s6d6zleXl5utWjRwvNdlmVZffr0se677z7LsiwrJyfHkmStW7fujHG+8847liTrhx9+8OwrKSmxGjRoYG3atMlr7MiRI62bb77ZsizLeuCBB6yOHTt6HZ8yZcpp1/o5SdZrr7121uOPPvqo1b17d8/n6dOnW4GBgdbXX3/t2bdmzRorICDAOnLkiGVZlnXeeedZS5cu9brOQw89ZCUmJlqWZVkHDhywJFkfffTRWb8XQM1iTgVg06pVqxQREaHy8nK53W7dcsstmjFjhud4586dveZRfPzxx9q7d68iIyO9rlNSUqJ9+/bp2LFjOnLkiHr27Ok5FhQUpB49epzWAjllx44dCgwMVJ8+fSod9969e1VcXKyrrrrKa39ZWZm6desmSdq9e7dXHJKUmJhY6e84ZdmyZcrIyNC+fftUWFioiooKRUVFeY1p2bKlmjdv7vU9brdbOTk5ioyM1L59+zRy5EjdeeednjEVFRWKjo6ucjwAagZJBWBTv379lJmZqZCQEMXFxSkoyPt/q/DwcK/PhYWF6t69u5YsWXLatZo2bVqtGMLCwqp8TmFhoSRp9erVXv+YSyfniZiyefNmJSUlaebMmRowYICio6P10ksv6bHHHqtyrAsXLjwtyQkMDDQWKwB7SCoAm8LDw9WmTZtKj7/ooou0bNkyNWvW7LTf1k8555xztGXLFl1++eWSTv5Gvn37dl100UVnHN+5c2e53W5t2LBB/fv3P+34qUqJy+Xy7OvYsaOcTqcOHjx41gpHhw4dPJNOT/nggw9+/Sb/x6ZNm9SqVSv95S9/8ez76quvTht38OBBHT58WHFxcZ7vCQgI0Pnnn6+YmBjFxcVp//79SkpKqtL3A6g9TNQEallSUpJ+97vfaciQIdq4caMOHDigd999V+PGjdPXX38tSbrvvvv08MMPa8WKFdqzZ49Gjx79i2tMnHvuuUpOTtYdd9yhFStWeK65fPlySVKrVq3kcDi0atUqfffddyosLFRkZKQmTpyolJQUPf/889q3b58+/PBDzZs3zzP58e6779YXX3yhSZMmKScnR0uXLtXixYurdL9t27bVwYMH9dJLL2nfvn3KyMg446TT0NBQJScn6+OPP9bGjRs1btw4DR8+XLGxsZKkmTNnKj09XRkZGfr888/16aefatGiRXr88cerFA+AmkNSAdSyBg0a6L333lPLli11ww03qEOHDho5cqRKSko8lYv7779ff/zjH5WcnKzExERFRkbq+uuv/8XrZmZm6g9/+INGjx6t9u3b684771RRUZEkqXnz5po5c6amTp2qmJgYjR07VpL00EMPKTU1Venp6erQoYMGDhyo1atXKyEhQdLJeQ6vvvqqVqxYoa5du2rBggWaM2dOle73uuuuU0pKisaOHasLL7xQmzZtUmpq6mnj2rRpoxtuuEHXXHONrr76anXp0sXrkdFRo0bp2Wef1aJFi9S5c2f16dNHixcv9sQKoO45rLPN/AIAAKgCKhUAAMAIkgoAAGAESQUAADCCpAIAABhBUgEAAIwgqQAAAEaQVAAAACNIKgAAgBEkFQAAwAiSCgAAYARJBQAAMOL/AdtGo1r7llHbAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Disparate impact ratio = Pr(Y=1|D=Female)/Pr(Y=1|D=Male)\n",
+        "Pr_Female = (32+89)/len(femalePredList)\n",
+        "Pr_Male = (10+106)/len(malePredList)\n",
+        "DIR = Pr_Female/Pr_Male\n",
+        "DIR"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "oiJxRKiFM0Ln",
+        "outputId": "8ba15415-6539-4d68-f90c-3b1d176ea112"
+      },
+      "execution_count": 86,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "0.9399829552904155"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 86
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Statistical parity difference = Pr(Y=1|D=Female) - Pr(Y=1|D=Male)\n",
+        "SPD = Pr_Female - Pr_Male\n",
+        "SPD"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "AsO_YlE4UOUh",
+        "outputId": "de76f78a-3858-4ee0-c808-632d091b988a"
+      },
+      "execution_count": 87,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "-0.029375431165872545"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 87
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Equal opportunity difference = TPR|D=Female - TPR|D=Male\n",
+        "# TPR = TP/TP+FN\n",
+        "TPR_Female = 89/(89+32)\n",
+        "TPR_Male = 106/(106+10)\n",
+        "EOD = TPR_Female - TPR_Male\n",
+        "EOD"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "vIQRn3rCU1o1",
+        "outputId": "628f963e-06e7-471e-efa5-7cdf7a445329"
+      },
+      "execution_count": 88,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "-0.1782559133656313"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 88
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Equalized odds difference = (FPR|D=Female - FPR|D=Male)/2\n",
+        "# FPR = FP/FP+TN\n",
+        "FPR_Female = 2/(2+140)\n",
+        "FPR_Male = 40/(40+81)\n",
+        "EqOD = (FPR_Female - FPR_Male)/2\n",
+        "EqOD"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Jb-YwaLdWMvp",
+        "outputId": "beb3b30c-87df-4487-cab7-1e2cfa4f912c"
+      },
+      "execution_count": 89,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "-0.15824700267722036"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 89
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "f3_Lawe5XHvI"
+      },
+      "execution_count": 89,
+      "outputs": []
     }
   ],
   "metadata": {


### PR DESCRIPTION
Updated the Jupyter Notebook to include the calculations for fairness metrics when considering biases that may exist with gender. 

The dataset was divided into two groups: one subset that only contains female candidates and the other subset that only has male candidates. The model was used to predict the outcomes for each student within either group and confusion matrices were created. From this, the fairness metrics of disparate impact ratio, statistical parity difference, equal opportunity difference, and equalized odds difference were found.